### PR TITLE
Implemented endpoint for medication-prescribe

### DIFF
--- a/resources/src/test/java/org/hl7/davinci/cdshooks/medicationprescribe/MedicationPrescribeRequestTest.java
+++ b/resources/src/test/java/org/hl7/davinci/cdshooks/medicationprescribe/MedicationPrescribeRequestTest.java
@@ -1,0 +1,29 @@
+package org.hl7.davinci.cdshooks.medicationprescribe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hl7.davinci.cdshooks.orderreview.OrderReviewRequest;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.model.DeviceRequest;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MedicationPrescribeRequestTest {
+  @Test
+  public void testReadingJson() throws IOException, FHIRException {
+    InputStream requestStream = this.getClass().getResourceAsStream("request.json");
+    ObjectMapper mapper = new ObjectMapper();
+    MedicationPrescribeRequest request = mapper.readValue(requestStream, MedicationPrescribeRequest.class);
+    assertNotNull(request);
+    assertEquals("1288992", request.getContext().getPatientId());
+    assertEquals("male", request.getPrefetch().getPatient().getGender().toCode());
+    MedicationRequest mr = (MedicationRequest) request.getContext().getMedications().getEntry().get(0).getResource();
+    assertNotNull(mr);
+    assertEquals("314076", mr.getMedicationCodeableConcept().getCoding().get(0).getCode());
+  }
+}

--- a/resources/src/test/resources/org/hl7/davinci/cdshooks/medicationprescribe/request.json
+++ b/resources/src/test/resources/org/hl7/davinci/cdshooks/medicationprescribe/request.json
@@ -1,0 +1,110 @@
+{
+  "context":{
+    "patientId":"1288992",
+    "encounterId":"89284",
+    "medications":{
+      "resourceType":"Bundle",
+      "entry":[
+        {
+          "resource": {
+            "resourceType": "MedicationRequest",
+            "status": "draft",
+            "intent": "plan",
+            "medicationCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                  "code": "314076"
+                }
+              ],
+              "text": "Lisinopril 10 MG Oral Tablet"
+            },
+            "subject": {
+              "reference": "Patient/1288992"
+            },
+            "authoredOn": "2018-08-08",
+            "insurance": {
+              "reference": "Coverage/1234"
+            },
+            "performer": {
+              "reference": "PractitionerRole/1234"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "prefetch": {
+    "patient": {
+      "resourceType": "Patient",
+      "gender": "male",
+      "birthDate": "1970-07-04"
+    },
+    "coverage": {
+      "resourceType": "Coverage",
+      "id": "1234",
+      "class": [
+        {
+          "type": {
+            "system": "http://hl7.org/fhir/coverage-class",
+            "code": "plan"
+          },
+          "value": "Medicare Part D"
+        }
+      ],
+      "payor": [
+        {
+          "reference": "Organization/e182fb07-e8c4-4cc0-8710-94f8b3a17b0b"
+        }
+      ]
+    },
+    "location": {
+      "resourceType": "Location",
+      "id": "89abea45-75d5-4730-a214-027fcb903ca1",
+      "address": {
+        "line": [
+          "100 Good St"
+        ],
+        "city": "Bedford",
+        "state": "MA",
+        "postalCode": "01730"
+      }
+    },
+    "practitionerRole": {
+      "practitioner": {
+        "reference": "Practitioner/13608725-a5f5-4276-b44a-1fe2c7273555"
+      },
+      "location": [
+        {
+          "reference": "Location/89abea45-75d5-4730-a214-027fcb903ca1"
+        }
+      ]
+    },
+    "insurer": {
+      "resourceType": "Organization",
+      "id": "e182fb07-e8c4-4cc0-8710-94f8b3a17b0b",
+      "name": "Centers for Medicare and Medicaid Services"
+    },
+    "provider": {
+      "resourceType": "Practitioner",
+      "id": "13608725-a5f5-4276-b44a-1fe2c7273555",
+      "identifier": [
+        {
+          "system": "http://hl7.org/fhir/sid/us-npi",
+          "value": "1122334455"
+        }
+      ],
+      "name": [
+        {
+          "family": "Doe",
+          "given": [
+            "Jane"
+          ],
+          "prefix": [
+            "Dr."
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/server/src/main/java/endpoint/cdshooks/services/crd/MedicationPrescribeService.java
+++ b/server/src/main/java/endpoint/cdshooks/services/crd/MedicationPrescribeService.java
@@ -1,0 +1,108 @@
+package endpoint.cdshooks.services.crd;
+
+import endpoint.components.CardBuilder;
+import endpoint.database.CoverageRequirementRule;
+import org.hl7.davinci.cdshooks.CdsResponse;
+import org.hl7.davinci.cdshooks.CdsService;
+import org.hl7.davinci.cdshooks.Hook;
+import org.hl7.davinci.cdshooks.Prefetch;
+import org.hl7.davinci.cdshooks.medicationprescribe.MedicationPrescribeRequest;
+import org.hl7.fhir.r4.model.Annotation;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@Component
+public class MedicationPrescribeService extends CdsService {
+  static final Logger logger = LoggerFactory.getLogger(MedicationPrescribeService.class);
+
+  public static final String ID = "medication-prescribe-crd";
+  public static final String TITLE = "medication-prescribe Coverage Requirements Discovery";
+  public static final Hook HOOK = Hook.MEDICATION_PRESCRIBE;
+  public static final String DESCRIPTION =
+      "Get information regarding the coverage requirements for durable medical equipment";
+  public static final Prefetch PREFETCH = null;
+
+  public MedicationPrescribeService() {
+    super(ID, HOOK, TITLE, DESCRIPTION, PREFETCH);
+  }
+
+  /**
+   * Handle the post request to the service.
+   * @param request The json request, parsed.
+   * @return
+   */
+  public CdsResponse handleRequest(@Valid @RequestBody MedicationPrescribeRequest request) {
+
+    logger.info("handleRequest: start");
+    logger.info("Medications bundle size: " + request.getContext().getMedications().getEntry().size());
+    MedicationRequest medicationRequest = null;
+    for (Bundle.BundleEntryComponent bec: request.getContext().getMedications().getEntry()) {
+      if (bec.hasResource()) {
+        medicationRequest = (MedicationRequest) bec.getResource();
+      }
+    }
+
+    if (request.getPrefetch().getPatient() != null) {
+      logger.info("handleRequest: patient birthdate: "
+          + request.getPrefetch().getPatient().getBirthDate().toString());
+    }
+    if (request.getPrefetch().getCoverage() != null) {
+      logger.info("handleRequest: coverage id: "
+          + request.getPrefetch().getCoverage().getId());
+    }
+    if (request.getPrefetch().getLocation() != null) {
+      logger.info("handleRequest: location address: "
+          + request.getPrefetch().getLocation().getAddress().getCity() + ", "
+          + request.getPrefetch().getLocation().getAddress().getState());
+    }
+    if (request.getPrefetch().getInsurer() != null) {
+      logger.info("handleRequest: insurer id: "
+          + request.getPrefetch().getInsurer().getName());
+    }
+    if (request.getPrefetch().getProvider() != null) {
+      logger.info("handleRequest: provider name: "
+          + request.getPrefetch().getProvider().getName().get(0).getPrefixAsSingleString() + " "
+          + request.getPrefetch().getProvider().getName().get(0).getFamily());
+    }
+
+    if (medicationRequest == null) {
+      // TODO: raise error
+      logger.error("No request provided!");
+    }
+
+    String msg = "response";
+
+    List<Annotation> list = medicationRequest.getNote();
+    if (!list.isEmpty()) {
+      msg = medicationRequest.getNote().get(0).getText();
+      logger.info("handleRequest: " + medicationRequest.getNote().get(0).getText());
+    } else {
+      logger.info("handleRequest: no notes specified");
+    }
+
+    CdsResponse response = new CdsResponse();
+
+    // TODO - Replace this with database lookup logic
+    response.addCard(CardBuilder.summaryCard("Responses from this service are currently hard coded."));
+
+    CoverageRequirementRule crr = new CoverageRequirementRule();
+    crr.setAgeRangeHigh(80);
+    crr.setAgeRangeLow(55);
+    crr.setEquipmentCode("E0424");
+    crr.setGenderCode("F".charAt(0));
+    crr.setNoAuthNeeded(false);
+    crr.setInfoLink("https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/"
+        + "MLNProducts/Downloads/Home-Oxygen-Therapy-Text-Only.pdf");
+
+    response.addCard(CardBuilder.transform(crr));
+    logger.info("handleRequest: end");
+    return response;
+  }
+}

--- a/server/src/main/java/endpoint/cdshooks/services/crd/OrderReviewService.java
+++ b/server/src/main/java/endpoint/cdshooks/services/crd/OrderReviewService.java
@@ -25,23 +25,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 
 @Component
-public class CrdCdsService extends CdsService {
+public class OrderReviewService extends CdsService {
 
-  static final Logger logger = LoggerFactory.getLogger(CrdCdsService.class);
+  static final Logger logger = LoggerFactory.getLogger(OrderReviewService.class);
 
-  public static final String ID = "coverage-requirements-discovery";
-  public static final String TITLE = "Coverage Requirements Discovery";
+  public static final String ID = "order-review-crd";
+  public static final String TITLE = "order-review Coverage Requirements Discovery";
   public static final Hook HOOK = Hook.ORDER_REVIEW;
   public static final String DESCRIPTION =
       "Get information regarding the coverage requirements for durable medical equipment";
   public static final Prefetch PREFETCH = null;
 
-  public CrdCdsService() {
+  public OrderReviewService() {
     super(ID, HOOK, TITLE, DESCRIPTION, PREFETCH);
   }
-
-  @Autowired
-  private FhirComponents fhirComponents;
 
   /**
    * Handle the post request to the service.

--- a/server/src/main/java/endpoint/controllers/CdsHooksController.java
+++ b/server/src/main/java/endpoint/controllers/CdsHooksController.java
@@ -1,10 +1,12 @@
 package endpoint.controllers;
 
-import endpoint.cdshooks.services.crd.CrdCdsService;
+import endpoint.cdshooks.services.crd.MedicationPrescribeService;
+import endpoint.cdshooks.services.crd.OrderReviewService;
 
 import javax.validation.Valid;
 
 import org.hl7.davinci.cdshooks.CdsResponse;
+import org.hl7.davinci.cdshooks.medicationprescribe.MedicationPrescribeRequest;
 import org.hl7.davinci.cdshooks.orderreview.OrderReviewRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,13 +20,18 @@ public class CdsHooksController {
   static final String URL_BASE = "/cds-services/";
 
 
-  @Autowired private CrdCdsService crdCdsService;
-
-  static final Class clz = OrderReviewRequest.class;
+  @Autowired private OrderReviewService orderReviewService;
+  @Autowired private MedicationPrescribeService medicationPrescribeService;
 
   @CrossOrigin
-  @PostMapping(value = URL_BASE + CrdCdsService.ID, consumes = "application/json;charset=UTF-8")
-  public CdsResponse handleRequest(@Valid @RequestBody OrderReviewRequest request) {
-    return crdCdsService.handleRequest(request);
+  @PostMapping(value = URL_BASE + OrderReviewService.ID, consumes = "application/json;charset=UTF-8")
+  public CdsResponse handleOrderReview(@Valid @RequestBody OrderReviewRequest request) {
+    return orderReviewService.handleRequest(request);
+  }
+
+  @CrossOrigin
+  @PostMapping(value = URL_BASE + MedicationPrescribeService.ID, consumes = "application/json;charset=UTF-8")
+  public CdsResponse handleMedicationPrescribe(@Valid @RequestBody MedicationPrescribeRequest request) {
+    return medicationPrescribeService.handleRequest(request);
   }
 }

--- a/server/src/test/java/endpoint/cdshooks/services/crd/OrderReviewServiceTest.java
+++ b/server/src/test/java/endpoint/cdshooks/services/crd/OrderReviewServiceTest.java
@@ -12,13 +12,13 @@ import org.hl7.fhir.r4.model.Enumerations;
 import org.junit.Test;
 
 
-public class CrdCdsServiceTest {
+public class OrderReviewServiceTest {
   @Test
   public void testHandleRequest() {
     Calendar cal = Calendar.getInstance();
     cal.set(1970, Calendar.JULY, 4);
     OrderReviewRequest request = CrdRequestCreator.createRequest(Enumerations.AdministrativeGender.MALE, cal.getTime());
-    CrdCdsService service = new CrdCdsService();
+    OrderReviewService service = new OrderReviewService();
     CdsResponse response = service.handleRequest(request);
     assertNotNull(response);
     assertEquals(1, response.getCards().size());

--- a/testingClient/src/main/java/TestClient.java
+++ b/testingClient/src/main/java/TestClient.java
@@ -28,7 +28,7 @@ public class TestClient {
             .createRequest(Enumerations.AdministrativeGender.MALE, cal.getTime());
 
     CloseableHttpClient client = HttpClients.createDefault();
-    HttpPost httpPost = new HttpPost("http://localhost:8080/cds-services/coverage-requirements-discovery");
+    HttpPost httpPost = new HttpPost("http://localhost:8080/cds-services/order-review-crd");
 
     ObjectMapper mapper = new ObjectMapper();
     ObjectWriter w = mapper.writer();


### PR DESCRIPTION
Both endpoints still need to be hooked up to the database layer.

NOTE: The URL for the order-review endpoint has changed to make room for
the new medication-prescribe hook.