### PR TITLE
Adding a code_system column to the database

### DIFF
--- a/request-generator/src/components/DropdownInput.js
+++ b/request-generator/src/components/DropdownInput.js
@@ -1,25 +1,27 @@
 import React, {Component} from 'react';
-import { connect } from 'react-redux';
 import {Dropdown} from 'semantic-ui-react';
 
-const options = [
-    { key: 'CPAP', text: '94660', value: 'fe' },
-    { key: 'Wheelchair', text: '97542', value: '97542' },
-    { key: 'Crutches', text: 'E0110', value: 'E0110' },
-    { key: 'Hospital Bed', text: 'E0250', value: 'E0250' },
-    { key: 'Continuous Glucose Monitoring', text: '95250', value: '95250' },
-    { key: 'Nebulizer', text: '94640', value:'94640' },
-    { key: 'Glucose Test Strip', text:'82947', value:'82947'},
-  ]
+const defaultValues = [
+    { key: 'CPAP', text: '94660', value: '94660', codeSystem: 'http://www.ama-assn.org/go/cpt' },
+    { key: 'Wheelchair', text: '97542', value: '97542', codeSystem: 'http://www.ama-assn.org/go/cpt' },
+    { key: 'Crutches', text: 'E0110', value: 'E0110', codeSystem: 'https://bluebutton.cms.gov/resources/codesystem/hcpcs' },
+    { key: 'Hospital Bed', text: 'E0250', value: 'E0250', codeSystem: 'https://bluebutton.cms.gov/resources/codesystem/hcpcs' },
+    { key: 'Continuous Glucose Monitoring', text: '95250', value: '95250', codeSystem: 'http://www.ama-assn.org/go/cpt' },
+    { key: 'Nebulizer', text: '94640', value:'94640', codeSystem: 'http://www.ama-assn.org/go/cpt' },
+    { key: 'Glucose Test Strip', text:'82947', value:'82947', codeSystem: 'http://www.ama-assn.org/go/cpt'},
+]
 
-  let blackBorder = "blackBorder";
-  
+function dropDownOptions() {
+  return defaultValues.map((v) => {return {key: v.key, text: `${v.key} - ${v.value}`, value: v.value}})
+}
+
+let blackBorder = "blackBorder";
+
 export default class DropdownInput extends Component {
-    constructor(props){
-        super(props);
-        this.state = { options }
-        };
-
+  constructor(props){
+    super(props);
+    this.state = { options: dropDownOptions() }
+  };
 
   handleAddition = (e, { value }) => {
     this.setState({
@@ -29,6 +31,7 @@ export default class DropdownInput extends Component {
 
   handleChange = (e, { value }) => {
     this.props.updateCB(this.props.elementName, value)
+    this.props.updateCB('codeSystem', defaultValues.find((v) => v.value === value).codeSystem)
     this.setState({ currentValue: value })
   }
 

--- a/request-generator/src/containers/RequestBuilder.js
+++ b/request-generator/src/containers/RequestBuilder.js
@@ -56,9 +56,9 @@ export default class RequestBuilder extends Component{
       }))
     }
 
-    updateStateElement = (elementName,text) => {
+    updateStateElement = (elementName, text) => {
         this.setState({ [elementName]: text});
-        }
+    }
 
     onInputChange(event){
         this.setState({ [event.target.name]: event.target.value });
@@ -352,11 +352,10 @@ export default class RequestBuilder extends Component{
                     codeCodeableConcept: {
                       coding: [
                         {
-                          system: "https://bluebutton.cms.gov/resources/codesystem/hcpcs",
+                          system: this.state.codeSystem,
                           code: this.state.code
                         }
-                      ],
-                      text: "Stationary Compressed Gaseous Oxygen System, Rental"
+                      ]
                     },
                     subject: {
                       reference: "Patient/12"

--- a/server/src/main/java/org/hl7/davinci/endpoint/database/CoverageRequirementRule.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/database/CoverageRequirementRule.java
@@ -25,6 +25,9 @@ public class CoverageRequirementRule {
   @Column(name = "equipment_code", nullable = false)
   private String equipmentCode;
 
+  @Column(name = "code_system", nullable = false)
+  private String codeSystem;
+
   @Column(name = "age_range_low", nullable = false)
   private int ageRangeLow;
 
@@ -97,25 +100,19 @@ public class CoverageRequirementRule {
     this.equipmentCode = equipmentCode;
   }
 
+  public String getCodeSystem() {
+    return codeSystem;
+  }
+
+  public void setCodeSystem(String codeSystem) {
+    this.codeSystem = codeSystem;
+  }
+
   @Override
   public String toString() {
-    return "(row id:"
-        + id
-        + ") "
-        + "  Rule [equipment_code: "
-        + equipmentCode
-        + ", ageRangeLow: "
-        + ageRangeLow
-        + ", ageRangeHigh: "
-        + ageRangeHigh
-        + ", genderCode: "
-        + genderCode
-        + "] "
-        + "  Outcome [noAuthNeeded: "
-        + noAuthNeeded
-        + ", infoLink: '"
-        + infoLink
-        + "']";
+    return String.format("(row id: %d) Rule [equipment_code: %s, code_system %s, age_range_low %d, age_range_high: %d" +
+        ", gender_code: %s] Outcome: [no_auth_needed: %s, info_link %s]", id, equipmentCode, codeSystem, ageRangeLow,
+        ageRangeHigh, genderCode, noAuthNeeded, infoLink);
   }
 
   public CoverageRequirementRule() {}

--- a/server/src/main/resources/db/sample_data.csv
+++ b/server/src/main/resources/db/sample_data.csv
@@ -1,10 +1,10 @@
-id,age_range_low,age_range_high,gender_code,equipment_code,no_auth_needed, info_link
-0,18,80,null,94660,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/downloads/PAP_DocCvg_Factsheet_ICN905064.pdf
-1,18,90,null,97542,TRUE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/downloads/PMDFactSheet07_Quark19.pdf
-2,21,50,null,E0110,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNMattersArticles/downloads/MM3791.pdf
-3,8,90,M,E0250,TRUE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforHospitalBedsandAccessories-ICN909476.pdf
-4,10,55,null,95250,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforGlucoseMonitors-ICN909465.pdf
-5,0,90,null,94640,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforNebulizersandRelatedDrugs-ICN909469.pdf
-6,18,60,null,82947,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforDiabeticTestStrips-ICN909185.pdf
-7,30,80,null,A5500,TRUE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforDiabeticShoes-ICN909471.pdf
-8,60,90,M,E0130,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforWalkers-ICN909483.pdf
+id,age_range_low,age_range_high,gender_code,equipment_code,code_system,no_auth_needed, info_link
+0,18,80,null,94660,http://www.ama-assn.org/go/cpt,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/downloads/PAP_DocCvg_Factsheet_ICN905064.pdf
+1,18,90,null,97542,http://www.ama-assn.org/go/cpt,TRUE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/downloads/PMDFactSheet07_Quark19.pdf
+2,21,50,null,E0110,https://bluebutton.cms.gov/resources/codesystem/hcpcs,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNMattersArticles/downloads/MM3791.pdf
+3,8,90,M,E0250,https://bluebutton.cms.gov/resources/codesystem/hcpcs,TRUE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforHospitalBedsandAccessories-ICN909476.pdf
+4,10,55,null,95250,http://www.ama-assn.org/go/cpt,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforGlucoseMonitors-ICN909465.pdf
+5,0,90,null,94640,http://www.ama-assn.org/go/cpt,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforNebulizersandRelatedDrugs-ICN909469.pdf
+6,18,60,null,82947,http://www.ama-assn.org/go/cpt,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforDiabeticTestStrips-ICN909185.pdf
+7,30,80,null,A5500,https://bluebutton.cms.gov/resources/codesystem/hcpcs,TRUE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforDiabeticShoes-ICN909471.pdf
+8,60,90,M,E0130,https://bluebutton.cms.gov/resources/codesystem/hcpcs,FALSE,https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforWalkers-ICN909483.pdf

--- a/server/src/main/resources/db/setup_db.sql
+++ b/server/src/main/resources/db/setup_db.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS coverage_requirement_rules (
     age_range_high integer NOT NULL,
     gender_code character(1),
     equipment_code character varying(255) NOT NULL,
+    code_system character varying(255) NOT NULL,
     no_auth_needed boolean NOT NULL,
     info_link character varying(2000)
 );

--- a/server/src/main/resources/templates/rules-table.html
+++ b/server/src/main/resources/templates/rules-table.html
@@ -12,6 +12,7 @@
             <td>Rule Ends at Age</td>
             <td>Gender</td>
             <td>Relevant Code (CPT / HCPCS)</td>
+            <td>Code System URL</td>
             <td>Documentation Required</td>
             <td>Coverage Documentation Requirement Information Link</td>
         </tr>
@@ -24,6 +25,7 @@
                 <td th:text="${rule.ageRangeHigh}"></td>
                 <td th:text="${rule.genderCode}"></td>
                 <td th:text="${rule.equipmentCode}"></td>
+                <td th:text="${rule.codeSystem}"></td>
                 <td th:text="! ${rule.noAuthNeeded}"></td>
                 <td th:text="${rule.infoLink}"></td>
             </tr>

--- a/server/src/test/java/ServerTest.java
+++ b/server/src/test/java/ServerTest.java
@@ -52,6 +52,7 @@ public class ServerTest {
     CoverageRequirementRule retVal = new CoverageRequirementRule();
     retVal.setInfoLink("https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/downloads/PMDFactSheet07_Quark19.pdf");
     retVal.setEquipmentCode("abc123");
+    retVal.setCodeSystem("https://bluebutton.cms.gov/resources/codesystem/hcpcs");
     retVal.setNoAuthNeeded(true);
     retVal.setAgeRangeHigh(42);
     retVal.setAgeRangeLow(0);
@@ -66,6 +67,7 @@ public class ServerTest {
     CoverageRequirementRule retVal = new CoverageRequirementRule();
     retVal.setInfoLink("test.com");
     retVal.setEquipmentCode("abc123");
+    retVal.setCodeSystem("https://bluebutton.cms.gov/resources/codesystem/hcpcs");
     retVal.setNoAuthNeeded(true);
     retVal.setAgeRangeHigh(42);
     retVal.setAgeRangeLow(0);


### PR DESCRIPTION
Codes belong to code systems. We have sample data that belongs to both
CPT and HCPCS. This change adds a column to the database to store the
code system. Updates the sample data with the correct code system. It
updates the CoverageRequirementRule model and the web UI. It also
updates the request-generator so that values there now have a code
system and that value is no longer hard coded to HCPCS.

Note that this is a work in progress. The CDS services do not yet check code systems and the finder does not support searching by it. I'm waiting until @daco101 is done making changes in the finder code to make that update.