### PR TITLE
request creator reference fix and orderreviewservice revert

### DIFF
--- a/resources/src/main/java/org/hl7/davinci/CrdRequestCreator.java
+++ b/resources/src/main/java/org/hl7/davinci/CrdRequestCreator.java
@@ -61,7 +61,7 @@ public class CrdRequestCreator {
     bec = new Bundle.BundleEntryComponent();
     bec.setResource(patient);
     prefetchBundle.addEntry(bec);
-    dr.setSubject(generateReference(ResourceType.Patient, patient));
+    dr.setSubject(new Reference(patient));
 
     // create a Practitioner object with ID set
     Practitioner provider = new Practitioner();
@@ -99,9 +99,9 @@ public class CrdRequestCreator {
 
     PractitionerRole pr = new PractitionerRole();
     pr.setId(idString());
-    pr.setPractitioner(generateReference(ResourceType.Practitioner, provider));
-    pr.addLocation(generateReference(ResourceType.Location, facility));
-    dr.setPerformer(generateReference(ResourceType.PractitionerRole, pr));
+    pr.setPractitioner(new Reference(provider));
+    pr.addLocation(new Reference(facility));
+    dr.setPerformer(new Reference(pr));
     bec = new Bundle.BundleEntryComponent();
     bec.setResource(pr);
     prefetchBundle.addEntry(bec);
@@ -113,8 +113,8 @@ public class CrdRequestCreator {
     Coverage.ClassComponent coverageClass = new Coverage.ClassComponent();
     coverageClass.setType(planCode).setValue("Medicare Part D");
     coverage.addClass_(coverageClass);
-    coverage.addPayor(generateReference(ResourceType.Organization, insurer));
-    dr.addInsurance(generateReference(ResourceType.Coverage, coverage));
+    coverage.addPayor(new Reference(insurer));
+    dr.addInsurance(new Reference(coverage));
     bec = new Bundle.BundleEntryComponent();
     bec.setResource(coverage);
     prefetchBundle.addEntry(bec);
@@ -125,10 +125,5 @@ public class CrdRequestCreator {
   private static String idString() {
     UUID uuid = UUID.randomUUID();
     return uuid.toString();
-  }
-
-  private static Reference generateReference(ResourceType type, Resource resource) {
-    Reference reference = new Reference();
-    return reference.setReference(String.format("%s/%s", type.toString(), resource.getId()));
   }
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderReviewService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderReviewService.java
@@ -102,17 +102,11 @@ public class OrderReviewService extends CdsService {
       }
 
       // See if the patient is in the prefetch
-      List<Patient> patients = Utilities.getResourcesOfTypeFromBundle(Patient.class, deviceRequestBundle);
-      if (patients.size() == 1) {
-        patient = patients.get(0);
-      } else {
-        // Not in the prefetch, see if it has been fetched.
-        try {
-          patient = (Patient) deviceRequest.getSubject().getResource();
-        } catch (Exception e) {
-          response
-              .addCard(CardBuilder.summaryCard("No patient could be (pre)fetched in this request"));
-        }
+      try {
+        patient = (Patient) deviceRequest.getSubject().getResource();
+      } catch (Exception e) {
+        response
+            .addCard(CardBuilder.summaryCard("No patient could be (pre)fetched in this request"));
       }
 
       if (patient != null && cc != null) {


### PR DESCRIPTION
This PR changes the request creator to use hapi references instead of reference strings so that these generated requests will work when passed in to the services (currently they will work if converted to json/xml and then parsed back into the service, but not if directly passed in as objects). 

It also reverts orderreviewservice to use linked resources only.