### PR TITLE
Small fixes for RequestBuilder

### DIFF
--- a/request-generator/src/containers/RequestBuilder.js
+++ b/request-generator/src/containers/RequestBuilder.js
@@ -128,9 +128,9 @@ export default class RequestBuilder extends Component{
       let json_request = this.getJson(1);
 
       this.setState({loading:true});
-          this.consoleLog("Fetching response from http://localhost:8090/cds-services/order-review-crd/",types.info)
+          this.consoleLog("Fetching response from http://localhost:8090/r4/cds-services/order-review-crd/",types.info)
           try{
-            const fhirResponse= await fetch("http://localhost:8090/cds-services/order-review-crd/",{
+            const fhirResponse= await fetch("http://localhost:8090/r4/cds-services/order-review-crd/",{
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json"
@@ -319,11 +319,10 @@ export default class RequestBuilder extends Component{
                     codeCodeableConcept: {
                       coding: [
                         {
-                          system: "https://bluebutton.cms.gov/resources/codesystem/hcpcs",
+                          system: this.state.codeSystem,
                           code: this.state.code
                         }
-                      ],
-                      text: "Stationary Compressed Gaseous Oxygen System, Rental"
+                      ]
                     },
                     subject: {
                       reference: "Patient/12"


### PR DESCRIPTION
Updates the URL for R4
Due to the way prefetch works in CDS Hooks, the DeviceRequest is present
in both the context as well as the prefetch. Previous changes fixed the
code system in the prefetch, but not in the context. This change fixes
the code system in the DeviceRequest in the context.