### PR TITLE
Warning card and remove devtools

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-data-rest')
     compile('org.springframework.boot:spring-boot-starter-thymeleaf')
     compile('org.springframework.boot:spring-boot-starter-security')
-    compile("org.springframework.boot:spring-boot-devtools")
 
     compile 'org.keycloak:keycloak-spring-boot-2-starter:4.0.0.Beta2'
 

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/MedicationPrescribeService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/MedicationPrescribeService.java
@@ -42,7 +42,6 @@ public class MedicationPrescribeService extends CdsService {
         CrdPrefetchTemplateElements.MEDICATION_REQUEST_BUNDLE.getQuery());
   }
 
-
   @Autowired
   CoverageRequirementRuleFinder ruleFinder;
 
@@ -113,6 +112,7 @@ public class MedicationPrescribeService extends CdsService {
 
     }
 
+    CardBuilder.errorCardIfNonePresent(response);
     logger.info("handleRequest: end");
     return response;
   }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderReviewService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderReviewService.java
@@ -121,7 +121,7 @@ public class OrderReviewService extends CdsService {
         }
       }
     }
-
+    CardBuilder.errorCardIfNonePresent(response);
     logger.info("handleRequest: end");
     return response;
   }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/MedicationPrescribeService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/MedicationPrescribeService.java
@@ -112,7 +112,7 @@ public class MedicationPrescribeService extends CdsService {
       }
 
     }
-
+    CardBuilder.errorCardIfNonePresent(response);
     logger.info("handleRequest: end");
     return response;
   }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/OrderReviewService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/OrderReviewService.java
@@ -123,7 +123,7 @@ public class OrderReviewService extends CdsService {
         }
       }
     }
-
+    CardBuilder.errorCardIfNonePresent(response);
     logger.info("handleRequest: end");
     return response;
   }

--- a/server/src/main/java/org/hl7/davinci/endpoint/components/CardBuilder.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/components/CardBuilder.java
@@ -1,5 +1,6 @@
 package org.hl7.davinci.endpoint.components;
 
+import org.cdshooks.CdsResponse;
 import org.hl7.davinci.endpoint.database.CoverageRequirementRule;
 import org.cdshooks.Card;
 import org.cdshooks.Link;
@@ -50,6 +51,23 @@ public class CardBuilder {
     Card card = baseCard();
     card.setSummary(summary);
     return card;
+  }
+
+  /**
+   * Creates an error card and adds it to the response if the response that is passed in
+   * does not contain any cards.
+   * @param response The response to check and add cards to
+   */
+  public static void errorCardIfNonePresent(CdsResponse response) {
+    if (response.getCards() == null || response.getCards().size() == 0) {
+      Card card = new Card();
+      card.setIndicator(Card.IndicatorEnum.WARNING);
+      Source source = new Source();
+      source.setLabel("Da Vinci CRD Reference Implementation");
+      card.setSource(source);
+      card.setSummary("Unable to process hook request from provided information.");
+      response.addCard(card);
+    }
   }
 
   private static Card baseCard() {


### PR DESCRIPTION
If the services reach the end of their processing, but the code in the
service has not added any cards, a warning card will be generated
stating that the request didn't have enough information. This typically
happens when the patient is null (broken reference) or it can't find a
CodeableConcept in the passed in request resource.

This also removes the spring devtools which was causing the server to
reload on each request.