### PR TITLE
Relax handling of resources without profiles for STU3 services

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/MedicationPrescribeService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/MedicationPrescribeService.java
@@ -16,6 +16,7 @@ import org.hl7.davinci.endpoint.components.PrefetchHydrator;
 import org.hl7.davinci.endpoint.database.CoverageRequirementRule;
 import org.hl7.davinci.endpoint.database.CoverageRequirementRuleFinder;
 import org.hl7.davinci.stu3.fhirresources.DaVinciMedicationRequest;
+import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
@@ -78,11 +79,17 @@ public class MedicationPrescribeService extends CdsService {
           "medicationRequestBundle could not be (pre)fetched in this request "));
       return response;
     }
-    List<DaVinciMedicationRequest> medicationRequestList = Utilities.getResourcesOfTypeFromBundle(
+    List medicationRequestList = Utilities.getResourcesOfTypeFromBundle(
         DaVinciMedicationRequest.class, medicationRequestBundle);
 
-    for (DaVinciMedicationRequest medicationRequest : medicationRequestList) {
+    if (medicationRequestList.isEmpty()) {
+      logger.warn("Unable to find any profiled MedicationRequests, looking for standard ones.");
+      medicationRequestList = Utilities.getResourcesOfTypeFromBundle(
+          MedicationRequest.class, medicationRequestBundle);
+    }
 
+    for (Object mr : medicationRequestList) {
+      MedicationRequest medicationRequest = (MedicationRequest) mr;
       Patient patient = null;
       CodeableConcept cc = null;
       try {

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/OrderReviewService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/OrderReviewService.java
@@ -20,6 +20,7 @@ import org.hl7.davinci.stu3.crdhook.orderreview.OrderReviewRequest;
 import org.hl7.davinci.stu3.fhirresources.DaVinciDeviceRequest;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.DeviceRequest;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.slf4j.Logger;
@@ -89,11 +90,17 @@ public class OrderReviewService extends CdsService {
           "deviceRequestBundle could not be (pre)fetched in this request "));
       return response;
     }
-    List<DaVinciDeviceRequest> deviceRequestList = Utilities.getResourcesOfTypeFromBundle(
+    List deviceRequestList = Utilities.getResourcesOfTypeFromBundle(
         DaVinciDeviceRequest.class, deviceRequestBundle);
 
-    for (DaVinciDeviceRequest deviceRequest : deviceRequestList) {
+    if (deviceRequestList.isEmpty()) {
+      logger.warn("Unable to find any profiled DeviceRequests, looking for standard ones.");
+      deviceRequestList = Utilities.getResourcesOfTypeFromBundle(
+          DeviceRequest.class, deviceRequestBundle);
+    }
 
+    for (Object dr : deviceRequestList) {
+      DeviceRequest deviceRequest = (DeviceRequest) dr;
       Patient patient = null;
       CodeableConcept cc = null;
       try {


### PR DESCRIPTION
Originally, the STU3 code would only pull DeviceRequests or MedicationRequests if they explicitly declare profile conformance, via the `meta` property. This change checks to see if any profiled resources were passed in as a part of the request. If not, it will log a warning and then check for non-profiled resources.