### PR TITLE
Resource id check

### DIFF
--- a/ehr-server/src/main/resources/data/5. patient.json
+++ b/ehr-server/src/main/resources/data/5. patient.json
@@ -2,5 +2,12 @@
   "resourceType": "Patient",
   "id": "pat1234",
   "gender": "male",
-  "birthDate": "1996-12-23"
+  "birthDate": "1996-12-23",
+  "address": [
+    {
+      "use": "home",
+      "type": "both",
+      "state": "MA"
+    }
+  ]
 }

--- a/resources/src/main/java/org/hl7/davinci/FatalRequestIncompleteException.java
+++ b/resources/src/main/java/org/hl7/davinci/FatalRequestIncompleteException.java
@@ -1,0 +1,11 @@
+package org.hl7.davinci;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST)
+public class FatalRequestIncompleteException extends RuntimeException {
+  public FatalRequestIncompleteException(String message) {
+    super(message);
+  }
+}

--- a/resources/src/main/java/org/hl7/davinci/r4/crdhook/CrdPrefetchTemplateElements.java
+++ b/resources/src/main/java/org/hl7/davinci/r4/crdhook/CrdPrefetchTemplateElements.java
@@ -16,6 +16,8 @@ public class CrdPrefetchTemplateElements {
           + "&_include=DeviceRequest:device"
           + "&_include=PractitionerRole:organization"
           + "&_include=PractitionerRole:practitioner"
+          + "&_include:recurse=PractitionerRole:location"
+          + "&_include:iterate=PractitionerRole:location"
           + "&_include=DeviceRequest:insurance:Coverage",
       Bundle.class);
 

--- a/server/src/main/java/org/hl7/davinci/endpoint/components/PrefetchHydrator.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/components/PrefetchHydrator.java
@@ -100,10 +100,6 @@ public class PrefetchHydrator {
    * Attempt to hydrate missing prefetch elements, note that this modifies the request object.
    */
   public void hydrate() {
-    if (cdsRequest.getFhirServer() == null) {
-      throw new FatalRequestIncompleteException("Attempting to fill the prefetch, but no fhir "
-          + "server provided. Either provide a full prefetch or provide a fhir server.");
-    }
     Object crdResponse = cdsRequest.getPrefetch();
     for (PrefetchTemplateElement prefetchElement : cdsService.getPrefetchElements()) {
       String prefetchKey = prefetchElement.getKey();
@@ -126,6 +122,10 @@ public class PrefetchHydrator {
         // if we can't hydrate the query, it probably means we didnt get an apprpriate resource
         // e.g. this could be a query template for a medication order but we have a device request
         if (hydratedPrefetchQuery != null) {
+          if (cdsRequest.getFhirServer() == null) {
+            throw new FatalRequestIncompleteException("Attempting to fill the prefetch, but no fhir "
+                + "server provided. Either provide a full prefetch or provide a fhir server.");
+          }
           try {
             PropertyUtils
                 .setProperty(crdResponse, prefetchKey,

--- a/server/src/test/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/EndToEndRequestPrefetchTest.java
+++ b/server/src/test/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/EndToEndRequestPrefetchTest.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -39,14 +40,8 @@ public class EndToEndRequestPrefetchTest {
   private String deviceRequestPrefetchResponseJson = FileUtils
       .readFileToString(new ClassPathResource("deviceRequestPrefetchResponse_r4.json").getFile(),
           Charset.defaultCharset());
-  private String prefetchUrl = "/DeviceRequest?_id=123"
-      + "&_include=DeviceRequest:patient"
-      + "&_include=DeviceRequest:performer"
-      + "&_include=DeviceRequest:requester"
-      + "&_include=DeviceRequest:device"
-      + "&_include=PractitionerRole:organization"
-      + "&_include=PractitionerRole:practitioner"
-      + "&_include=DeviceRequest:insurance:Coverage";
+  private String prefetchUrlMatcher = "\\/DeviceRequest\\?_id=123.*";
+
   @LocalServerPort
   private int port;
   @Autowired
@@ -57,7 +52,7 @@ public class EndToEndRequestPrefetchTest {
 
   @Test
   public void shouldSuccessfullyFillPreFetch() {
-    stubFor(get(urlEqualTo(prefetchUrl))
+    stubFor(get(urlMatching(prefetchUrlMatcher))
         .willReturn(aResponse()
             .withStatus(200)
             .withHeader("Content-Type", "application/json")
@@ -77,7 +72,7 @@ public class EndToEndRequestPrefetchTest {
 
   @Test
   public void shouldFailToFillPrefetch() {
-    stubFor(get(urlEqualTo(prefetchUrl))
+    stubFor(get(urlMatching(prefetchUrlMatcher))
         .willReturn(aResponse()
             .withStatus(404)));
 

--- a/server/src/test/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderReviewServiceTest.java
+++ b/server/src/test/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderReviewServiceTest.java
@@ -4,12 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Calendar;
-
 import org.cdshooks.CdsResponse;
+import org.hl7.davinci.FatalRequestIncompleteException;
 import org.hl7.davinci.r4.CrdRequestCreator;
+import org.hl7.davinci.r4.crdhook.CrdPrefetch;
 import org.hl7.davinci.r4.crdhook.orderreview.OrderReviewRequest;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Enumerations;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +23,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest
 public class OrderReviewServiceTest {
 
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
   @Autowired
   private OrderReviewService service;
 
@@ -26,10 +32,41 @@ public class OrderReviewServiceTest {
   public void testHandleRequest() {
     Calendar cal = Calendar.getInstance();
     cal.set(1970, Calendar.JULY, 4);
-    OrderReviewRequest request = CrdRequestCreator.createOrderReviewRequest(Enumerations.AdministrativeGender.MALE, cal.getTime(), "MA", "MA");
+    OrderReviewRequest request = CrdRequestCreator
+        .createOrderReviewRequest(Enumerations.AdministrativeGender.MALE, cal.getTime(), "MA",
+            "MA");
     CdsResponse response = service.handleRequest(request);
     assertNotNull(response);
     assertEquals(1, response.getCards().size());
-    assertEquals("Documentation is required for the desired device or service", response.getCards().get(0).getSummary());
+    assertEquals("Documentation is required for the desired device or service",
+        response.getCards().get(0).getSummary());
+  }
+
+  @Test
+  public void testPrefetchNeededNoFhirServerThrowsError() {
+    Calendar cal = Calendar.getInstance();
+    cal.set(1970, Calendar.JULY, 4);
+    OrderReviewRequest request = CrdRequestCreator
+        .createOrderReviewRequest(Enumerations.AdministrativeGender.MALE, cal.getTime(), "MA",
+            "MA");
+    request.setPrefetch(new CrdPrefetch()); //empty the prefetch
+    request.setFhirServer(null); //empty the fhir server
+
+    thrown.expect(FatalRequestIncompleteException.class);
+    service.handleRequest(request);
+  }
+
+  @Test
+  public void testPrefetchNeededNoResourceIdThrowsError() {
+    Calendar cal = Calendar.getInstance();
+    cal.set(1970, Calendar.JULY, 4);
+    OrderReviewRequest request = CrdRequestCreator
+        .createOrderReviewRequest(Enumerations.AdministrativeGender.MALE, cal.getTime(), "MA",
+            "MA");
+    request.setPrefetch(new CrdPrefetch()); //empty the prefetch
+    request.getContext().getOrders().getEntryFirstRep().getResource().setId((IIdType) null);
+
+    thrown.expect(FatalRequestIncompleteException.class);
+    service.handleRequest(request);
   }
 }


### PR DESCRIPTION
This PR modifies the hydrator so it will throw an error (which is returned to the client with status 400) if there are resources without id's which we need, and also to throw an error if we need to do a prefetch but there is no fhir server provided.

