### PR TITLE
Add states to ui

### DIFF
--- a/request-generator/src/components/App.js
+++ b/request-generator/src/components/App.js
@@ -1,6 +1,9 @@
 import React, {Component} from 'react';
 import RequestBuilder from '../containers/RequestBuilder';
 export default class App extends Component {
+    componentDidMount(){
+        document.title = "Request Generator"
+      }
     render() {
         return (
             <div>

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -169,13 +169,13 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     requestService.edit(requestLog);
 
     List<String> codes = new ArrayList<>();
-
+    List<String> codeSystems = new ArrayList<>();
     List<CoverageRequirementRule> rules = new ArrayList<>();
     for (CoverageRequirementRuleQuery query : queries) {
       query.execute();
       rules.addAll(query.getResponse()); // will be zero or more
       codes.add(query.getCriteria().getEquipmentCode());
-      codes.add(query.getCriteria().getCodeSystem());
+      codeSystems.add(query.getCriteria().getCodeSystem());
     }
     requestLog.setPatientAge(queries.get(0).getCriteria().getAge());
     requestLog.setPatientGender(String.valueOf(queries.get(0).getCriteria().getGenderCode()));
@@ -183,7 +183,7 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     requestLog.setProviderAddressState(queries.get(0).getCriteria().getProviderAddressState());
     requestLog.setCode(String.join(", ", codes));
 
-    List<String> codeSystems = new ArrayList<>();
+
     requestLog.setCodeSystem(String.join(", ", codeSystems));
 
     if (rules.size() == 0) {

--- a/server/src/main/java/org/hl7/davinci/endpoint/database/CoverageRequirementRule.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/database/CoverageRequirementRule.java
@@ -16,18 +16,17 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "coverage_requirement_rules")
 public class CoverageRequirementRule {
+  // the order in which these fields appear will be the order
+  // in which they are organized in the data table.
+  // The desired configuration is:
+  // ID | AGELOW | AGEHIGH | GENDER | CODE |
+  // SYSTEM | PATIENTADDRESS | PRACTITIONERADDRESS | DOC REQ | LINK |
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id", updatable = false, nullable = false)
   private long id;
 
   //    The following fields describe the rule
-  @Column(name = "equipment_code", nullable = false)
-  private String equipmentCode;
-
-  @Column(name = "code_system", nullable = false)
-  private String codeSystem;
-
   @Column(name = "age_range_low", nullable = false)
   private int ageRangeLow;
 
@@ -37,18 +36,26 @@ public class CoverageRequirementRule {
   @Column(name = "gender_code", nullable = true)
   private Character genderCode;
 
+  @Column(name = "equipment_code", nullable = false)
+  private String equipmentCode;
+
+  @Column(name = "code_system", nullable = false)
+  private String codeSystem;
+
   @Column(name = "patient_address_state", nullable = true, length = 2)
   private String patientAddressState;
 
   @Column(name = "provider_address_state", nullable = true, length = 2)
   private String providerAddressState;
 
+  @Column(name = "no_auth_needed", nullable = false)
+  private boolean noAuthNeeded;
+
   //    The following fields describe the rule outcome
   @Column(name = "info_link", nullable = true, length = 2000)
   private String infoLink;
 
-  @Column(name = "no_auth_needed", nullable = false)
-  private boolean noAuthNeeded;
+
 
   public long getId() {
     return id;
@@ -133,8 +140,8 @@ public class CoverageRequirementRule {
   @Override
   public String toString() {
     return String.format("(row id: %d) Rule [equipment_code: %s, code_system %s, age_range_low %d, age_range_high: %d"
-        + ", gender_code: %s] Outcome: [no_auth_needed: %s, info_link %s]", id, equipmentCode, codeSystem, ageRangeLow,
-        ageRangeHigh, genderCode, noAuthNeeded, infoLink);
+        + ", gender_code: %s, patient_address_state: %s, practitioner_address_state] Outcome: [no_auth_needed: %s, info_link %s]", id, equipmentCode, codeSystem, ageRangeLow,
+        ageRangeHigh, genderCode, patientAddressState, providerAddressState, noAuthNeeded, infoLink);
   }
 
   public CoverageRequirementRule() {}

--- a/server/src/main/request_logging/src/components/HealthInfo.js
+++ b/server/src/main/request_logging/src/components/HealthInfo.js
@@ -18,7 +18,7 @@ export default class HealthInfo extends Component {
     componentDidMount(){
         // temporarily hard code the data
         var dataProps = this.props.data;
-        this.setState({requestInfo: {"age":dataProps.patientAge,"gender":dataProps.patientGender,"code":dataProps.code,"codeSystem":codeSystemConversion[dataProps.codeSystem]}})
+        this.setState({requestInfo: {"age":dataProps.patientAge,"gender":dataProps.patientGender,"Patient State":dataProps.patientAddressState,"Provider State":dataProps.providerAddressState,"code":dataProps.code,"codeSystem":codeSystemConversion[dataProps.codeSystem]}})
     }
 
      render() {

--- a/server/src/main/resources/templates/data.html
+++ b/server/src/main/resources/templates/data.html
@@ -18,7 +18,7 @@
 <div class="container-fluid">
 <h1 th:text="${foo}"></h1>
 
-<div th:replace="rules-table :: table"></div>
+<div th:replace="rules-table :: table(headers = ${headers})"></div>
 
 <div>
     <form action="#" th:action="@{/data}" th:object="${datum}" method="post">

--- a/server/src/main/resources/templates/rules-table.html
+++ b/server/src/main/resources/templates/rules-table.html
@@ -13,12 +13,20 @@
             <td>Gender</td>
             <td>Relevant Code (CPT / HCPCS)</td>
             <td>Code System URL</td>
+            <td>Patient Address</td>
+            <td>Practitioner Address</td>
             <td>Documentation Required</td>
             <td>Coverage Documentation Requirement Information Link</td>
         </tr>
         </thead>
         <tbody>
         <th:block th:each="rule : ${rules}">
+            <!--<tr>-->
+                <!--<th:block th:each="header : ${headers}">-->
+                    <!--<td th:text="${rule.__${header}__}"></td>-->
+                <!--</th:block>-->
+            <!--</tr>-->
+
             <tr>
                 <td th:text="${rule.id}"></td>
                 <td th:text="${rule.ageRangeLow}"></td>
@@ -26,6 +34,8 @@
                 <td th:text="${rule.genderCode}"></td>
                 <td th:text="${rule.equipmentCode}"></td>
                 <td th:text="${rule.codeSystem}"></td>
+                <td th:text="${rule.patientAddressState}"></td>
+                <td th:text="${rule.providerAddressState}"></td>
                 <td th:text="! ${rule.noAuthNeeded}"></td>
                 <td th:text="${rule.infoLink}"></td>
             </tr>


### PR DESCRIPTION
this adds the state info to the data table, which is displayed at `/data` and `/` on the server, and the request log.   The request generator already supports states from a previous PR.  

This also changes the request generators title from "React App" to "Request Generator".  