### PR TITLE
Smart app cards

### DIFF
--- a/ehr-server/src/main/java/org/hl7/davinci/ehrserver/ClientAuthorizationInterceptor.java
+++ b/ehr-server/src/main/java/org/hl7/davinci/ehrserver/ClientAuthorizationInterceptor.java
@@ -28,8 +28,6 @@ public class ClientAuthorizationInterceptor extends AuthorizationInterceptor {
 
   @Override
   public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
-
-    System.out.println("henlo");
     String useOauth = Config.get("use_oauth");
     if (!Boolean.parseBoolean(useOauth)) {
       return new RuleBuilder()

--- a/ehr-server/src/main/java/org/hl7/davinci/ehrserver/ClientAuthorizationInterceptor.java
+++ b/ehr-server/src/main/java/org/hl7/davinci/ehrserver/ClientAuthorizationInterceptor.java
@@ -28,23 +28,27 @@ public class ClientAuthorizationInterceptor extends AuthorizationInterceptor {
 
   @Override
   public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
+
+    System.out.println("henlo");
     String useOauth = Config.get("use_oauth");
     if (!Boolean.parseBoolean(useOauth)) {
       return new RuleBuilder()
           .allowAll()
           .build();
     }
+
     CloseableHttpClient client = HttpClients.createDefault();
 
     String authHeader = theRequestDetails.getHeader("Authorization");
     // Get the token and drop the "Bearer"
     if (authHeader == null) {
       return new RuleBuilder()
+          .allow().metadata().andThen()
           .denyAll("No authorization header present")
           .build();
     }
-    String token = authHeader.split(" ")[1];
 
+    String token = authHeader.split(" ")[1];
     String secret = Config.get("client_secret");
     String clientId = Config.get("client_id");
 
@@ -77,6 +81,7 @@ public class ClientAuthorizationInterceptor extends AuthorizationInterceptor {
           .build();
     } else {
       return new RuleBuilder()
+          .allow().metadata().andThen()
           .denyAll("Rejected OAuth token - failed to introspect")
           .build();
     }

--- a/ehr-server/src/main/java/org/hl7/davinci/ehrserver/EhrServer.java
+++ b/ehr-server/src/main/java/org/hl7/davinci/ehrserver/EhrServer.java
@@ -1,29 +1,27 @@
 package org.hl7.davinci.ehrserver;
 
-import java.util.Collection;
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.servlet.ServletException;
-
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Meta;
-import org.springframework.web.context.ContextLoaderListener;
-import org.springframework.web.context.WebApplicationContext;
-
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.jpa.dao.DaoConfig;
 import ca.uhn.fhir.jpa.dao.IFhirSystemDao;
-import ca.uhn.fhir.jpa.provider.r4.JpaConformanceProviderR4;
 import ca.uhn.fhir.jpa.provider.r4.JpaSystemProviderR4;
 import ca.uhn.fhir.jpa.search.DatabaseBackedPagingProvider;
 import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
 import ca.uhn.fhir.rest.api.EncodingEnum;
-import ca.uhn.fhir.rest.server.*;
+import ca.uhn.fhir.rest.server.ETagSupportEnum;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Meta;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.context.ContextLoaderListener;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.servlet.ServletException;
+import java.util.Collection;
+import java.util.List;
 
 public class EhrServer extends RestfulServer {
   static final Logger logger = LoggerFactory.getLogger(EhrServer.class);
@@ -71,7 +69,7 @@ public class EhrServer extends RestfulServer {
      * is a nice addition.
      */
     IFhirSystemDao<Bundle, Meta> systemDao = myAppCtx.getBean("mySystemDaoR4", IFhirSystemDao.class);
-    JpaConformanceProviderR4 confProvider = new JpaConformanceProviderR4(this, systemDao,
+    ServerConformance confProvider = new ServerConformance(this, systemDao,
         myAppCtx.getBean(DaoConfig.class));
     confProvider.setImplementationDescription("EHR Server");
     setServerConformanceProvider(confProvider);
@@ -107,7 +105,7 @@ public class EhrServer extends RestfulServer {
      */
     Collection<IServerInterceptor> interceptorBeans = myAppCtx.getBeansOfType(IServerInterceptor.class).values();
     for (IServerInterceptor interceptor : interceptorBeans) {
-      this.registerInterceptor(interceptor);
+      registerInterceptor(interceptor);
     }
 
     /*

--- a/ehr-server/src/main/java/org/hl7/davinci/ehrserver/FhirServerConfig.java
+++ b/ehr-server/src/main/java/org/hl7/davinci/ehrserver/FhirServerConfig.java
@@ -134,29 +134,6 @@ public class FhirServerConfig extends BaseJavaConfigR4 {
     return new ClientAuthorizationInterceptor();
   }
 
-  /**
-   * This interceptor filters the headers, origin of the data, and the methods.
-   */
-  @Bean(autowire = Autowire.BY_TYPE)
-  public IServerInterceptor corsInterceptor() {
-    logger.info("FhirServerConfig::corsInterceptor");
-    CorsConfiguration config = new CorsConfiguration();
-    config.addAllowedHeader("x-fhir-starter");
-    config.addAllowedHeader("Origin");
-    config.addAllowedHeader("Accept");
-    config.addAllowedHeader("X-Requested-With");
-    config.addAllowedHeader("Content-Type");
-
-    // Allow all origins for now since the port the server gets run on might change
-    config.addAllowedOrigin("*");
-
-    config.addExposedHeader("Location");
-    config.addExposedHeader("Content-Location");
-    config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
-
-    // Create the interceptor and register it
-    return new CorsInterceptor(config);
-  }
 
   /**
    * Setup a new JPA transaction manager.

--- a/ehr-server/src/main/java/org/hl7/davinci/ehrserver/ServerConformance.java
+++ b/ehr-server/src/main/java/org/hl7/davinci/ehrserver/ServerConformance.java
@@ -1,0 +1,41 @@
+package org.hl7.davinci.ehrserver;
+
+import ca.uhn.fhir.jpa.dao.DaoConfig;
+import ca.uhn.fhir.jpa.dao.IFhirSystemDao;
+import ca.uhn.fhir.jpa.provider.r4.JpaConformanceProviderR4;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.UriType;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+public class ServerConformance extends JpaConformanceProviderR4 {
+
+  public ServerConformance(RestfulServer theRestfulServer, IFhirSystemDao<Bundle, Meta> theSystemDao, DaoConfig theDaoConfig) {
+    super(theRestfulServer, theSystemDao, theDaoConfig);
+  }
+
+  @Override
+  public CapabilityStatement getServerConformance(HttpServletRequest theRequest) {
+    Extension securityExtension = new Extension();
+    securityExtension.setUrl("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris");
+    securityExtension.addExtension()
+        .setUrl("authorize")
+        .setValue(new UriType(Config.get("oauth_authorize")));
+    securityExtension.addExtension()
+        .setUrl("token")
+        .setValue(new UriType(Config.get("oauth_token")));
+    CapabilityStatement.CapabilityStatementRestSecurityComponent securityComponent = new CapabilityStatement.CapabilityStatementRestSecurityComponent();
+    securityComponent.setCors(true);
+    securityComponent
+        .addExtension(securityExtension);
+
+    CapabilityStatement regularConformance = super.getServerConformance(theRequest);
+    regularConformance.getRest().get(0).setSecurity(securityComponent);
+    return regularConformance;
+  }
+}

--- a/ehr-server/src/main/resources/fhirServer.properties
+++ b/ehr-server/src/main/resources/fhirServer.properties
@@ -1,5 +1,5 @@
 client_id = app-token
-client_secret= af3057e5-f29e-4c15-83bc-63b4d0506df2
+client_secret= #replaceMe#
 realm=ClientFhirServer
 use_oauth = true
 oauth_token = http://localhost:8180/auth/realms/ClientFhirServer/protocol/openid-connect/token

--- a/ehr-server/src/main/resources/fhirServer.properties
+++ b/ehr-server/src/main/resources/fhirServer.properties
@@ -1,4 +1,6 @@
 client_id = app-token
-client_secret= #replaceMe#
+client_secret= af3057e5-f29e-4c15-83bc-63b4d0506df2
 realm=ClientFhirServer
-use_oauth = false
+use_oauth = true
+oauth_token = http://localhost:8180/auth/realms/ClientFhirServer/protocol/openid-connect/token
+oauth_authorize =  http://localhost:8180/auth/realms/ClientFhirServer/protocol/openid-connect/auth

--- a/ehr-server/src/main/webapp/WEB-INF/web.xml
+++ b/ehr-server/src/main/webapp/WEB-INF/web.xml
@@ -95,7 +95,7 @@
 		<init-param>
 			<description>A comma separated list of allowed headers when making a non simple CORS request.</description>
 			<param-name>cors.allowed.headers</param-name>
-			<param-value>X-FHIR-Starter,Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Prefer</param-value>
+			<param-value>Authorization,X-FHIR-Starter,Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Prefer</param-value>
 		</init-param>
 		<init-param>
 			<description>A comma separated list non-standard response headers that will be exposed to XHR2 object.</description>

--- a/resources/src/main/java/org/hl7/davinci/PatientInfo.java
+++ b/resources/src/main/java/org/hl7/davinci/PatientInfo.java
@@ -4,6 +4,7 @@ public class PatientInfo {
   private Character patientGenderCode = null;
   private String patientAddressState = null;
   private Integer patientAge = null;
+  private String patientId = null;
 
   /**
    * Constructor for the patientInfo class.
@@ -12,10 +13,11 @@ public class PatientInfo {
    * @param patientAge the ingteger value of the patients age
    */
   public PatientInfo(Character patientGenderCode, String patientAddressState,
-      Integer patientAge) {
+      Integer patientAge, String patientId) {
     this.patientGenderCode = patientGenderCode;
     this.patientAddressState = patientAddressState;
     this.patientAge = patientAge;
+    this.patientId = patientId;
   }
 
   public Character getPatientGenderCode() {
@@ -41,4 +43,12 @@ public class PatientInfo {
   public void setPatientAge(Integer patientAge) {
     this.patientAge = patientAge;
   }
+
+  public String getPatientId() { return patientId; }
+
+  public void setPatientId(String patientId) {
+    this.patientId = patientId;
+  }
+
 }
+

--- a/resources/src/main/java/org/hl7/davinci/r4/Utilities.java
+++ b/resources/src/main/java/org/hl7/davinci/r4/Utilities.java
@@ -120,11 +120,13 @@ public class Utilities {
     Character patientGenderCode = null;
     String patientAddressState = null;
     Integer patientAge = null;
+    String patientId = null;
 
     try {
       patientGenderCode = patient.getGender().getDisplay().charAt(0);
       patientAddressState = Utilities.getFirstPhysicalHomeAddress(patient.getAddress()).getState();
       patientAge = SharedUtilities.calculateAge(patient.getBirthDate());
+      patientId = patient.getId();
     } catch (Exception e) {
       //TODO: logger.error("Error parsing needed info from the device request bundle.", e);
     }
@@ -138,8 +140,11 @@ public class Utilities {
     if (patientAge == null) {
       throw new RequestIncompleteException("Patient found with no birthdate. Looking in Patient -> birthDate.");
     }
+    if (patientId == null) {
+      throw new RequestIncompleteException("Patient found with no ID.");
+    }
 
-    return new PatientInfo(patientGenderCode, patientAddressState, patientAge);
+    return new PatientInfo(patientGenderCode, patientAddressState, patientAge, patientId);
   }
 
   /**

--- a/resources/src/main/java/org/hl7/davinci/stu3/Utilities.java
+++ b/resources/src/main/java/org/hl7/davinci/stu3/Utilities.java
@@ -91,11 +91,13 @@ public class Utilities {
     Character patientGenderCode = null;
     String patientAddressState = null;
     Integer patientAge = null;
+    String patientId = null;
 
     try {
       patientGenderCode = patient.getGender().getDisplay().charAt(0);
       patientAddressState = Utilities.getFirstPhysicalHomeAddress(patient.getAddress()).getState();
       patientAge = SharedUtilities.calculateAge(patient.getBirthDate());
+      patientId = patient.getId();
     } catch (Exception e) {
       //TODO: logger.error("Error parsing needed info from the device request bundle.", e);
     }
@@ -109,8 +111,11 @@ public class Utilities {
     if (patientAge == null) {
       throw new RequestIncompleteException("Patient found with no birthdate. Looking in Patient -> birthDate.");
     }
+    if (patientId == null) {
+      throw new RequestIncompleteException("Patient found with no ID.");
+    }
 
-    return new PatientInfo(patientGenderCode, patientAddressState, patientAge);
+    return new PatientInfo(patientGenderCode, patientAddressState, patientAge, patientId);
   }
 
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/YamlConfig.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/YamlConfig.java
@@ -14,13 +14,18 @@ public class YamlConfig {
   // properties of the same name automatically.
 
   private boolean checkJwt;
+  private String launchUrl;
 
   public boolean getCheckJwt() {
     return checkJwt;
   }
 
+  public String getLaunchUrl() { return launchUrl; }
+
   public void setCheckJwt(boolean check) {
     checkJwt = check;
   }
+
+  public void setLaunchUrl(String launch) { launchUrl = launch; }
 
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/components/CardBuilder.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/components/CardBuilder.java
@@ -20,7 +20,7 @@ public class CardBuilder {
    * @param crr coverage rule from the database
    * @return card with appropriate information
    */
-  public static Card transform(CoverageRequirementRule crr) {
+  public static Card transform(CoverageRequirementRule crr, String launchUrl) {
     Card card = baseCard();
     if (crr.getNoAuthNeeded()) {
       String summary = String
@@ -33,8 +33,13 @@ public class CardBuilder {
       link.setUrl(crr.getInfoLink());
       link.setType("absolute");
       link.setLabel("Documentation Requirements");
+      Link launchLink = new Link();
+      launchLink.setUrl(launchUrl);
+      launchLink.setType("smart");
+      launchLink.setLabel("SMART App");
       List<Link> links = new ArrayList<>();
       links.add(link);
+      links.add(launchLink);
       card.setLinks(links);
       String detail = "There are documentation requirements for the following criteria:"
           + "\n Patient is of gender: '%s' and between the ages of: %d and %d and lives in state: '%s'"

--- a/server/src/main/java/org/hl7/davinci/endpoint/database/CoverageRequirementRuleCriteria.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/database/CoverageRequirementRuleCriteria.java
@@ -8,6 +8,7 @@ public class CoverageRequirementRuleCriteria {
   private String codeSystem;
   private String patientAddressState;
   private String providerAddressState;
+  private String patientId;
 
   public CoverageRequirementRuleCriteria(){}
 
@@ -17,8 +18,8 @@ public class CoverageRequirementRuleCriteria {
    */
   public String toString() {
     return String.format(
-        "age=%d, genderCode=%c, equipmentCode=%s, codeSystem=%s, patientAddressState=%s, providerAddressState=%s",
-        age, genderCode, equipmentCode, codeSystem, patientAddressState, providerAddressState);
+        "age=%d, genderCode=%c, equipmentCode=%s, codeSystem=%s, patientAddressState=%s, providerAddressState=%s, patientId=%s",
+        age, genderCode, equipmentCode, codeSystem, patientAddressState, providerAddressState, patientId);
 
   }
 
@@ -52,6 +53,11 @@ public class CoverageRequirementRuleCriteria {
     return this;
   }
 
+  public CoverageRequirementRuleCriteria setPatientId(String patientId) {
+    this.patientId = patientId;
+    return this;
+  }
+
   public int getAge() {
     return age;
   }
@@ -75,4 +81,6 @@ public class CoverageRequirementRuleCriteria {
   public String getProviderAddressState() {
     return providerAddressState;
   }
+
+  public String getPatientId() { return patientId; }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -16,3 +16,4 @@ server:
   port: 8090
 
 checkJwt: false
+launchUrl: http://localhost:3050/launch

--- a/server/src/test/java/org/hl7/davinci/endpoint/cdshooks/components/CardBuilderTest.java
+++ b/server/src/test/java/org/hl7/davinci/endpoint/cdshooks/components/CardBuilderTest.java
@@ -33,7 +33,7 @@ public class CardBuilderTest {
     crr.setInfoLink("http://www.mitre.org");
     Card card = CardBuilder.transform(crr,"dummyLaunchUrl.com");
     assertEquals("Documentation is required for the desired device or service", card.getSummary());
-    assertEquals(1, card.getLinks().size());
+    assertEquals(2, card.getLinks().size());
     assertEquals("http://www.mitre.org", card.getLinks().get(0).getUrl());
   }
 }

--- a/server/src/test/java/org/hl7/davinci/endpoint/cdshooks/components/CardBuilderTest.java
+++ b/server/src/test/java/org/hl7/davinci/endpoint/cdshooks/components/CardBuilderTest.java
@@ -17,7 +17,7 @@ public class CardBuilderTest {
     crr.setEquipmentCode("E0424");
     crr.setGenderCode("F".charAt(0));
     crr.setNoAuthNeeded(true);
-    Card card = CardBuilder.transform(crr);
+    Card card = CardBuilder.transform(crr,"dummyLaunchUrl.com");
     assertEquals("No documentation is required for a device or service with code: E0424", card.getSummary());
     assertNull(card.getLinks());
   }
@@ -31,7 +31,7 @@ public class CardBuilderTest {
     crr.setGenderCode("F".charAt(0));
     crr.setNoAuthNeeded(false);
     crr.setInfoLink("http://www.mitre.org");
-    Card card = CardBuilder.transform(crr);
+    Card card = CardBuilder.transform(crr,"dummyLaunchUrl.com");
     assertEquals("Documentation is required for the desired device or service", card.getSummary());
     assertEquals(1, card.getLinks().size());
     assertEquals("http://www.mitre.org", card.getLinks().get(0).getUrl());


### PR DESCRIPTION
This PR adds a link to the cards returned to the request generator which launches the smart on FHIR app.  The DTR app needs to be running for it to work.  To test it you can switch the ID of the patient on the incoming request from the request generator (or directly make a request to one of the service endpoints and follow the link returned in the JSON and choose some patient ID) to some patient that exists in the EHR server.  The program will fail currently if the patient does not have a name, which most of the sample patients do not have. 

The app launch will trigger a chain of auth events, first acquiring the token and authorization keycloak endpoints from the fhir server conformance statement.  The token and authorization endpoints can be set in `fhirServer.properties` in the resources folder of the EHR server.  They will default to the keycloak server that the project used to use.  

The launch page gets the conformance statement, parses out the token and authorization endpoints, and acquires an authorization code from the auth endpoint.  It will redirect you to the login page and you'll have to login using some user account that's set up on your local running keycloak instance.  This behavior can be swapped out for some token based approach, as the code  received from logging in gets saved in a cookie and is used to bypass this step on any subsequent launch while the access code is active.  The page then redirects to the `/index` page on the smart APP which will display the name of the patient in context.  It will use the code to query the keycloak token endpoint to get an actual access token which can be used to get resources from the fhir server.

It will then query the fhir server with the access token, which will introspect it and return the requested patient on success.  