### PR TITLE
fix smart url builder for patientid

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -216,10 +216,10 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
 
   protected String smartUrlBuilder(String patientId, String fhirBase) {
     String launchUrl = myConfig.getLaunchUrl();
-    if (fhirBase.endsWith("/")) {
+    if (fhirBase != null && fhirBase.endsWith("/")) {
       fhirBase = fhirBase.substring(0, fhirBase.length() - 1);
     }
-    if (patientId.startsWith("Patient/")) {
+    if (patientId != null && patientId.startsWith("Patient/")) {
       patientId = patientId.substring(8,patientId.length());
     }
     return launchUrl + "?iss=" + fhirBase + "&patientId=" + patientId;

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -216,9 +216,14 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
 
   protected String smartUrlBuilder(String patientId, String fhirBase) {
     String launchUrl = myConfig.getLaunchUrl();
+    if (fhirBase.endsWith("/")) {
+      fhirBase = fhirBase.substring(0, fhirBase.length() - 1);
+    }
+    if (patientId.startsWith("Patient/")) {
+      patientId = patientId.substring(8,patientId.length());
+    }
     return launchUrl + "?iss=" + fhirBase + "&patientId=" + patientId;
   }
-
 
   protected List<CoverageRequirementRuleQuery> resourcesToQueries(List<?> codings, boolean patientIsNull,
       boolean practitionerRoleIsNull,


### PR DESCRIPTION
The PR tweaks the smart url builder to return a patient id and fhir server url that are ready to use by the js smart client.