### PR TITLE
added build command to update node_interfaces

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -50,16 +50,6 @@ This functionality can be turned off and on by changing the `checkJWt` property 
 
 ## Building Web Apps
 
-React based pages like the `/public` and `/requests` must be built into static javascript and css to be served.
-
-The react .jsx code should be edited directly in their respective folders in `/server/resources` and then be built.
-To build them, follow these steps:
-
-1.  Navigate into the desired directory in a terminal or command prompt
-2.  Run `npm run build`
-3.  Transfer the .js and .css files to the static folder
-4.  Change the respective .html file to reference the new files
-
-
+To edit the web apps, the code in `src/main/resources/node_interfaces` should be updated.  These changes will not be reflected by the server.  To build the jsx files, run `npm run-script buildx`.  This command will run a bash script that will automatically build the files out and move them to the correct directory to be hosted by the spring server.
 
 

--- a/server/src/main/resources/node_interfaces/buildout.sh
+++ b/server/src/main/resources/node_interfaces/buildout.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+npm run-script build  # build the static files out
+
+if [ -f ../static/js/main.index.js ]; then
+    rm -rf ../static/js/main.index.js
+    echo Deleted JS
+fi
+
+if [ -f ../static/main.index.css ]; then
+    rm -rf ../static/main.index.css
+    echo Deleted CSS
+fi
+
+
+if [ -f ./build/static/css/main.*.css ]; then
+    mv ./build/static/css/main.*.css ../static/main.index.css
+    echo Moved CSS
+fi
+
+if [ -f ./build/static/js/main.*.js ]; then
+    mv ./build/static/js/main.*.js ../static/js/main.index.js
+    echo Moved JS
+fi

--- a/server/src/main/resources/node_interfaces/package.json
+++ b/server/src/main/resources/node_interfaces/package.json
@@ -30,6 +30,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "buildx": "./buildout.sh"
   }
 }


### PR DESCRIPTION
Added a `buildx` command to the `node_interfaces` subproject which automatically moves the built out files into the correct folder so that they are used by the server when it is run.  Running `npm run buildx` or `npm run-script buildx` will build out `node_interfaces`, delete the old static files in the server's `static` folder, rename the built out .css and .js files, and move them to the proper directory.