### PR TITLE
[DME196, DME197] Connectathon changes

### DIFF
--- a/resources/src/main/java/org/hl7/davinci/r4/Utilities.java
+++ b/resources/src/main/java/org/hl7/davinci/r4/Utilities.java
@@ -153,7 +153,7 @@ public class Utilities {
    * @throws RequestIncompleteException thrown if critical information is missing.
    */
   public static PractitionerRoleInfo getPractitionerRoleInfo(
-      PractitionerRole practitionerRole) throws RequestIncompleteException {
+      PractitionerRole practitionerRole, boolean checkLocation) throws RequestIncompleteException {
     Location practitionerRoleLocation = null;
     String locationAddressState = null;
 
@@ -163,10 +163,10 @@ public class Utilities {
     } catch (Exception e) {
       //TODO: logger.error("Error parsing needed info from the device request bundle.", e);
     }
-    if (practitionerRoleLocation == null) {
+    if (practitionerRoleLocation == null & checkLocation) {
       throw new RequestIncompleteException("Practitioner Role Location not found.");
     }
-    if (locationAddressState == null) {
+    if (locationAddressState == null & checkLocation) {
       throw new RequestIncompleteException("Patient Role Location found with no Address State.");
     }
 

--- a/server/src/main/java/org/hl7/davinci/endpoint/YamlConfig.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/YamlConfig.java
@@ -15,6 +15,7 @@ public class YamlConfig {
 
   private boolean checkJwt;
   private String launchUrl;
+  private boolean checkPractitionerLocation;
 
   public boolean getCheckJwt() {
     return checkJwt;
@@ -28,4 +29,11 @@ public class YamlConfig {
 
   public void setLaunchUrl(String launch) { launchUrl = launch; }
 
+  public void setCheckPractitionerLocation(boolean checkPractitionerLocation) {
+    this.checkPractitionerLocation = checkPractitionerLocation;
+  }
+
+  public boolean isCheckPractitionerLocation() {
+    return checkPractitionerLocation;
+  }
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -267,7 +267,9 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
           .setPatientAddressState(patientInfo.getPatientAddressState())
           .setCodeSystem(codeSystem)
           .setEquipmentCode(code)
-          .setProviderAddressState(practitionerRoleInfo.getLocationAddressState())
+          .setProviderAddressState(
+              practitionerRoleInfo != null
+                  ? practitionerRoleInfo.getLocationAddressState() : null)
           .setPatientId(patientInfo.getPatientId());
       queries.add(query);
     }
@@ -276,7 +278,7 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
 
   private List<CoverageRequirementRuleQuery> getQueries(requestTypeT request)
       throws RequestIncompleteException {
-    List<CoverageRequirementRuleQuery> queries = makeQueries(request);
+    List<CoverageRequirementRuleQuery> queries = makeQueries(request, myConfig);
     if (queries.size() == 0) {
       throw new RequestIncompleteException(
           "Unable to (pre)fetch any supported resources from the bundle.");
@@ -285,7 +287,7 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
   }
 
   // Implement this in child class
-  public abstract List<CoverageRequirementRuleQuery> makeQueries(requestTypeT request)
+  public abstract List<CoverageRequirementRuleQuery> makeQueries(requestTypeT request, YamlConfig options)
       throws RequestIncompleteException;
 
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/MedicationPrescribeService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/MedicationPrescribeService.java
@@ -8,6 +8,7 @@ import org.hl7.davinci.PatientInfo;
 import org.hl7.davinci.PractitionerRoleInfo;
 import org.hl7.davinci.PrefetchTemplateElement;
 import org.hl7.davinci.RequestIncompleteException;
+import org.hl7.davinci.endpoint.YamlConfig;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.CdsService;
 import org.hl7.davinci.endpoint.database.CoverageRequirementRuleQuery;
 import org.hl7.davinci.r4.FhirComponents;
@@ -50,7 +51,7 @@ public class MedicationPrescribeService extends CdsService<MedicationPrescribeRe
    * @throws RequestIncompleteException if the request cannot be parsed.
    */
   public List<CoverageRequirementRuleQuery> makeQueries(
-      MedicationPrescribeRequest orderReviewRequest)
+      MedicationPrescribeRequest orderReviewRequest, YamlConfig options)
       throws RequestIncompleteException {
     List<CoverageRequirementRuleQuery> queries = new ArrayList<>();
     Bundle medicationRequestBundle = orderReviewRequest.getPrefetch().getMedicationRequestBundle();
@@ -76,7 +77,7 @@ public class MedicationPrescribeService extends CdsService<MedicationPrescribeRe
               .getReference());
         }
         patientInfo = Utilities.getPatientInfo(patient);
-        practitionerRoleInfo = Utilities.getPractitionerRoleInfo(practitionerRole);
+        practitionerRoleInfo = Utilities.getPractitionerRoleInfo(practitionerRole, options.isCheckPractitionerLocation());
 
         queries.addAll(
             this.resourcesToQueries(codings, patient == null, practitionerRole == null, patientInfo,

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderReviewService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderReviewService.java
@@ -8,6 +8,7 @@ import org.hl7.davinci.PatientInfo;
 import org.hl7.davinci.PractitionerRoleInfo;
 import org.hl7.davinci.PrefetchTemplateElement;
 import org.hl7.davinci.RequestIncompleteException;
+import org.hl7.davinci.endpoint.YamlConfig;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.CdsService;
 import org.hl7.davinci.endpoint.database.CoverageRequirementRuleQuery;
 import org.hl7.davinci.r4.FhirComponents;
@@ -68,7 +69,7 @@ public class OrderReviewService extends CdsService<OrderReviewRequest> {
    * @return a list of the information required.
    * @throws RequestIncompleteException if the request cannot be parsed.
    */
-  public List<CoverageRequirementRuleQuery> makeQueries(OrderReviewRequest orderReviewRequest)
+  public List<CoverageRequirementRuleQuery> makeQueries(OrderReviewRequest orderReviewRequest, YamlConfig options)
       throws RequestIncompleteException {
     List<CoverageRequirementRuleQuery> queries = new ArrayList<>();
     List<Bundle> allBundles = getOrderReviewBundles(orderReviewRequest);
@@ -113,7 +114,7 @@ public class OrderReviewService extends CdsService<OrderReviewRequest> {
           practitionerRole = (PractitionerRole) deviceRequest.getPerformer().get(0).getResource();
         }
         patientInfo = Utilities.getPatientInfo(patient);
-        practitionerRoleInfo = Utilities.getPractitionerRoleInfo(practitionerRole);
+        practitionerRoleInfo = Utilities.getPractitionerRoleInfo(practitionerRole, options.isCheckPractitionerLocation());
 
         queries.addAll(
             this.resourcesToQueries(codings, patient == null, practitionerRole == null, patientInfo,

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/MedicationPrescribeService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/MedicationPrescribeService.java
@@ -8,6 +8,7 @@ import org.hl7.davinci.PatientInfo;
 import org.hl7.davinci.PractitionerRoleInfo;
 import org.hl7.davinci.PrefetchTemplateElement;
 import org.hl7.davinci.RequestIncompleteException;
+import org.hl7.davinci.endpoint.YamlConfig;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.CdsService;
 import org.hl7.davinci.endpoint.database.CoverageRequirementRuleQuery;
 import org.hl7.davinci.stu3.FhirComponents;
@@ -49,7 +50,7 @@ public class MedicationPrescribeService extends CdsService<MedicationPrescribeRe
    * @throws RequestIncompleteException if the request cannot be parsed.
    */
   public List<CoverageRequirementRuleQuery> makeQueries(
-      MedicationPrescribeRequest medicationPrescribeRequest)
+      MedicationPrescribeRequest medicationPrescribeRequest,  YamlConfig options)
       throws RequestIncompleteException {
     List<CoverageRequirementRuleQuery> queries = new ArrayList<>();
     Bundle medicationRequestBundle = medicationPrescribeRequest.getPrefetch()

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/OrderReviewService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/OrderReviewService.java
@@ -5,6 +5,7 @@ import org.cdshooks.Hook;
 import org.hl7.davinci.PatientInfo;
 import org.hl7.davinci.PractitionerRoleInfo;
 import org.hl7.davinci.PrefetchTemplateElement;
+import org.hl7.davinci.endpoint.YamlConfig;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.CdsService;
 import org.hl7.davinci.RequestIncompleteException;
 import org.hl7.davinci.endpoint.database.CoverageRequirementRuleQuery;
@@ -56,7 +57,7 @@ public class OrderReviewService extends CdsService<OrderReviewRequest>  {
    * @return a list of the information required.
    * @throws RequestIncompleteException if the request cannot be parsed.
    */
-  public List<CoverageRequirementRuleQuery> makeQueries(OrderReviewRequest orderReviewRequest)
+  public List<CoverageRequirementRuleQuery> makeQueries(OrderReviewRequest orderReviewRequest,  YamlConfig options)
       throws RequestIncompleteException {
     List<CoverageRequirementRuleQuery> queries = new ArrayList<>();
     Bundle deviceRequestBundle = orderReviewRequest.getPrefetch().getDeviceRequestBundle();

--- a/server/src/main/java/org/hl7/davinci/endpoint/components/CardBuilder.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/components/CardBuilder.java
@@ -41,7 +41,7 @@ public class CardBuilder {
       links.add(link);
       links.add(launchLink);
       card.setLinks(links);
-      String detail = "There are documentation requirements for the following criteria:"
+      String detail = "There are [documentation requirements](" + crr.getInfoLink() + ") for the following criteria:"
           + "\n Patient is of gender: '%s' and between the ages of: %d and %d and lives in state: '%s'"
           + "\n Device or service has code of '%s'"
           + "\n Service is requested in state: '%s'.";

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -17,3 +17,4 @@ server:
 
 checkJwt: false
 launchUrl: http://localhost:3050/launch
+checkPractitionerLocation: false


### PR DESCRIPTION
This creates a link in the card detail (which we don't show) which is clickable on the words `documentation requirements`.  If Epic's system is like the CDS hooks sandbox, they will be using react markdown, which accepts links in the `[text](link)` format.

Also creates a setting in the servers `application.yml` that can make practitioner location optional.  When `checkPractitionerLocation` is set to true, the program will throw an error is no location is found.  If it is set to false, the program will still search for cards with or without a practitioner location.  If there is no location provided, rules requiring practitioner location are ignored.  