### PR TITLE
[213] Request log pages

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -42,4 +42,6 @@ This functionality can be turned off and on by changing the `checkJWt` property 
 
 To edit the web apps, the code in `src/main/resources/node_interfaces` should be updated.  These changes will not be reflected by the server.  To build the jsx files, run `npm run-script buildx`.  This command will run a bash script that will automatically build the files out and move them to the correct directory to be hosted by the spring server.
 
+You can also run the gradle task `buildReact` in the `server` directory to do the same thing.  Alternatively, running the bash script itself using `./buildout.sh` with `node_interfaces` as a working directory.
+
 

--- a/server/src/main/resources/node_interfaces/public/index.html
+++ b/server/src/main/resources/node_interfaces/public/index.html
@@ -19,6 +19,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <meta name="ctx" content="/" />
+
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 

--- a/server/src/main/resources/node_interfaces/src/App.js
+++ b/server/src/main/resources/node_interfaces/src/App.js
@@ -21,6 +21,9 @@ const Category = () => (
 )
 
 let baseUrl = document.querySelector("meta[name='ctx']").getAttribute("content");
+if(!baseUrl) {
+    baseUrl='/';
+}
 class App extends Component {
   render() {
       const homeUrl = baseUrl;

--- a/server/src/main/resources/node_interfaces/src/components/requestLog/request.css
+++ b/server/src/main/resources/node_interfaces/src/components/requestLog/request.css
@@ -90,6 +90,7 @@
     font-weight: bold;
 }
 .orderButton{
+    width:30px;
     border:1px black solid;
     background-color:white;
     color:black;
@@ -98,6 +99,10 @@
 .orderButton:hover{
     background-color:black;
     color:white;
+}
+
+.firstButton {
+    margin-left: 0px;
 }
 
 .pageNumber{

--- a/server/src/main/resources/node_interfaces/src/containers/RequestLog.css
+++ b/server/src/main/resources/node_interfaces/src/containers/RequestLog.css
@@ -1,3 +1,31 @@
 .fontSetter{
     font-family: 'Courier New', Courier, monospace;
 }
+
+.viewButton { 
+    height: 25px;
+    background-color: none;
+    border: none;
+    font-weight: bold;
+
+    color: #777;
+}
+
+.forwardView {
+    text-align:left;
+    padding-left:5px;
+}
+
+.backwardView {
+    padding-right: 5px;
+    text-align:left;
+
+}
+.viewButton:hover {
+    color: black;
+}
+
+.invisible {
+    opacity:0;
+    pointer-events:none;
+}

--- a/server/src/main/resources/node_interfaces/src/containers/RequestLog.js
+++ b/server/src/main/resources/node_interfaces/src/containers/RequestLog.js
@@ -6,14 +6,16 @@ let tempDatabase={
 }
 
 let baseUrl = document.querySelector("meta[name='ctx']").getAttribute("content");
-let entriesPerPage = 10;
+let entriesPerPage = 15;
+let pagesShown = 9;
 export default class RequestLog extends Component {
     constructor(props){
         super(props);
         this.state={
             data:[],
             dataToShow:null,
-            page:1
+            page:1,
+            view:1
 
         };
          
@@ -21,6 +23,7 @@ export default class RequestLog extends Component {
         this.getPage = this.getPage.bind(this);
         this.renderPageNumbers = this.renderPageNumbers.bind(this);
         this.getData = this.getData.bind(this);
+        this.increaseView = this.increaseView.bind(this);
     }
 
     
@@ -30,7 +33,7 @@ export default class RequestLog extends Component {
     }
 
     async getData(){
-        const requestData = await fetch(baseUrl+'api/requests', {
+        const requestData = await fetch('http://localhost:8090/api/requests', {
             method: 'GET',
             headers: {
                 'Accept': 'application/json'
@@ -97,9 +100,15 @@ export default class RequestLog extends Component {
     }
 
 
+    increaseView(value){
+        this.setState({view: this.state.view+value});
+    }
 
 
      render() {
+         const showForward = (this.state.view+pagesShown-1)<(this.state.data.length/entriesPerPage);
+         const showBackward = this.state.view!=1;
+         console.log(this.state.view);
          // page should only render when switching pages. 
          // on page switch we scroll to top automatically.
         window.scrollTo(0, 0)
@@ -141,15 +150,40 @@ export default class RequestLog extends Component {
                  </div>
 
                  <div className="pageNumber">
+                        <span>
+                            <button className={"viewButton backwardView " + (!showBackward?"invisible":'')} 
+                                    onClick={()=>{this.increaseView(-this.state.view+1)}}>
+                                &lt;&lt;  
+                            </button>
+                            <button className={"viewButton backwardView " + (!showBackward?"invisible":'')}
+                                    onClick={()=>{this.increaseView(-1)}}>
+                                &lt; 
+                            </button>
+                        </span>
                      {this.renderPageNumbers().map(number=>{
+                         if(number >= this.state.view && number < this.state.view+pagesShown)
                          return <button 
                          key={number}
-                         className={"orderButton " + [this.state.page===number?"active":""]}
+                         className={"orderButton "+((number==this.state.view)?"firstButton ":'')+ [this.state.page===number?"active":""]}
                          onClick={()=> this.getPage(number)}
                          >
                          {number}
                          </button>
                      })}
+                        <span>
+                            <button className={"viewButton forwardView " + (!showForward?"invisible":'')} 
+                                    onClick={()=>{this.increaseView(1)}}>
+                                &gt;
+                            </button>
+                            <button className={"viewButton forwardView " + (!showForward?"invisible":'')} 
+                                    onClick={()=>{this.increaseView(Math.ceil(this.state.data.length/entriesPerPage) - (this.state.view+pagesShown-1))}}>
+                                &gt;&gt;
+                            </button>
+                        </span>
+
+
+
+
                  </div>
                 
              </div>

--- a/server/src/main/resources/node_interfaces/src/containers/RequestLog.js
+++ b/server/src/main/resources/node_interfaces/src/containers/RequestLog.js
@@ -33,7 +33,7 @@ export default class RequestLog extends Component {
     }
 
     async getData(){
-        const requestData = await fetch('http://localhost:8090/api/requests', {
+        const requestData = await fetch(baseUrl+'api/requests', {
             method: 'GET',
             headers: {
                 'Accept': 'application/json'


### PR DESCRIPTION
Fixes the little page number buttons on the request log.  It now only shows 9 pages at a time, and there are little arrow buttons that you can use to scroll through the pages.

Also fixed inconsistent button sizing and centering.

Testing might be a bit difficult since you need to run the server version.  I haven't included the static files in this PR since the structure of the static files gets changed in my other PR #102 and they will have to be rebuilt anyway (and also my react scripts was installed globally and now builds it the new way so I can't get the old static scripts to even upload here)

If you want to test it, run `buildout.sh` first and then run the server.  You'll have to make over 150 requests to see the new changes in action, or you can change `entriesPerPage` at the top of `RequestLog.js` to reduce the amount of requests it displays per page and then build that out into static files with `buildout.sh`. Then you can get away with 10 requests at a `entriesPerPage` of 1.
