### PR TITLE
[266] changed codes in the questionnaire for change to admin codes

### DIFF
--- a/server/src/main/jib/smartAppFhirArtifacts/home-oxygen-questionnaire.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/home-oxygen-questionnaire.json
@@ -33,15 +33,15 @@
           {
             "concept": [
               {
-                "code": "M",
+                "code": "male",
                 "display": "Male"
               },
               {
-                "code": "F",
+                "code": "female",
                 "display": "Female"
               },
               {
-                "code": "Other",
+                "code": "other",
                 "display": "Other"
               }
             ]


### PR DESCRIPTION
Didn't actually require any change to the cql, since the FHIR was written correctly.  Gender is a `code` type, not `coding`, meaning it's taken from a specific valueset as defined by the spec, in this case the `administrativeGender` valueSet.  The code for the choice input in the questionnaire builder in the DTR app was changed instead to deal with codes that might not come with a specified system, but an implied system.  Of course, that implied value set still needs to get passed to the contained resources of the questionnaire resource somehow.  

So really all this is doing is aligning the codes between the questionnaires value set and the administrativeGender value set.