### PR TITLE
Initial pass at refactoring DTR CQL. Multiple libraries and value sets

### DIFF
--- a/server/src/main/jib/smartAppFhirArtifacts/BasicPatientInfoPrepopulate.cql
+++ b/server/src/main/jib/smartAppFhirArtifacts/BasicPatientInfoPrepopulate.cql
@@ -1,0 +1,30 @@
+library BasicPatientInfo version '0.0.1'
+using FHIR version '3.0.0'
+include FHIRHelpers version '3.0.0' called FHIRHelpers
+
+parameter device_request DeviceRequest
+
+context Patient
+
+define function GetMiddleInitials(name FHIR.HumanName):
+  Substring(Combine((name.given given return Substring(given.value,0,1)),', '),3)
+
+define Today: Today()
+
+// Grab patient FHIR HumanName
+define Name: singleton from (Patient.name name where name.use.value = 'official')
+
+// Extract useful name elements
+define LastName: "Name".family.value
+define MiddleInitial: GetMiddleInitials("Name")
+define FirstName: "Name".given[0].value
+
+define Gender: Patient.gender.value
+define DateOfBirth: Patient.birthDate.value
+
+define CoverageResource: singleton from (
+  [Coverage] coverage
+    // pull coverage resource id from the device request insurance extension
+    where ('Coverage/' + coverage.id) = ((device_request.extension ext where ext.url = 'http://build.fhir.org/ig/HL7/davinci-crd/STU3/ext-insurance.html')[0].value.reference.value))
+
+define MedicareId: "CoverageResource".subscriberId.value

--- a/server/src/main/jib/smartAppFhirArtifacts/OxygenTherapyPrepopulation.cql
+++ b/server/src/main/jib/smartAppFhirArtifacts/OxygenTherapyPrepopulation.cql
@@ -139,20 +139,6 @@ define function GetMiddleInitials(name FHIR.HumanName):
 
 define Today: Today()
 
-// basic patient stuff
-define PatientName: singleton from (Patient.name name where name.use.value = 'official')
-define PatientLastName: "PatientName".family.value
-define PatientMiddleInitial: GetMiddleInitials("PatientName")
-define PatientFirstName: "PatientName".given[0].value
-define PatientGender: Patient.gender.value
-define PatientDateOfBirth: Patient.birthDate.value
-
-define PatientCoverageResource: singleton from (
-  [Coverage] coverage
-    // pull coverage resource id from the device request insurance extension
-    where ('Coverage/' + coverage.id) = ((device_request.extension ext where ext.url = 'http://build.fhir.org/ig/HL7/davinci-crd/STU3/ext-insurance.html')[0].value.reference.value))
-define PatientMedicareId: "PatientCoverageResource".subscriberId.value
-
 // coverage requirement info
 define RelevantDiagnoses: {
   if exists(Confirmed(ActiveOrRecurring([Condition: "COPD_Codes"]))) then 'COPD' else 'null',

--- a/server/src/main/jib/smartAppFhirArtifacts/OxygenTherapyPrepopulation.cql
+++ b/server/src/main/jib/smartAppFhirArtifacts/OxygenTherapyPrepopulation.cql
@@ -14,10 +14,7 @@ codesystem "LOINC": 'http://loinc.org'
 codesystem "SNOMED-CT": 'http://snomed.info/sct'
 
 //COPD_Codes
-code "J44": 'J44' from "ICD-10-CM"
-code "J44.0": 'J44.0' from "ICD-10-CM"
-code "J44.1": 'J44.1' from "ICD-10-CM"
-code "J44.9": 'J44.9' from "ICD-10-CM"
+valueset "COPD": 'urn:hl7:davinci:crd:valueset-copd'
 
 //Bronchiectasis_Codes
 code "J47": 'J47' from "ICD-10-CM"
@@ -109,7 +106,6 @@ code "8510008": '8510008' from "SNOMED-CT"
 parameter device_request DeviceRequest
 
 // Relevant Diagnosis Code Lists
-define "COPD_Codes": { "J44", "J44.0", "J44.1", "J44.9" }
 define "Bronchiectasis_Codes": { "J47", "J47.0", "J47.1", "J47.9" }
 define "Diffuse_interstitial_lung_disease_Codes": { "J84", "J84.0", "J84.01", "J84.02", "J84.03",
   "J84.09", "J84.1", "J84.10", "J84.11", "J84.111", "J84.112", "J84.113", "J84.114", "J84.115",
@@ -141,7 +137,7 @@ define Today: Today()
 
 // coverage requirement info
 define RelevantDiagnoses: {
-  if exists(Confirmed(ActiveOrRecurring([Condition: "COPD_Codes"]))) then 'COPD' else 'null',
+  if exists(Confirmed(ActiveOrRecurring([Condition: "COPD"]))) then 'COPD' else 'null',
   if exists(Confirmed(ActiveOrRecurring([Condition: "Bronchiectasis_Codes"]))) then 'Bronchiectasis' else 'null',
   if exists(Confirmed(ActiveOrRecurring([Condition: "Diffuse_interstitial_lung_disease_Codes"]))) then 'Diffuse Interstitial Lung Disease' else 'null',
   if exists(Confirmed(ActiveOrRecurring([Condition: "Cystic_fibrosis_Codes"]))) then 'Cystic Fibrosis' else 'null',

--- a/server/src/main/jib/smartAppFhirArtifacts/PositiveAirwayPressurePrepopulate.cql
+++ b/server/src/main/jib/smartAppFhirArtifacts/PositiveAirwayPressurePrepopulate.cql
@@ -31,20 +31,6 @@ define function GetMiddleInitials(name FHIR.HumanName):
 
 define Today: Today()
 
-// basic patient stuff
-define PatientName: singleton from (Patient.name name where name.use.value = 'official')
-define PatientLastName: "PatientName".family.value
-define PatientMiddleInitial: GetMiddleInitials("PatientName")
-define PatientFirstName: "PatientName".given[0].value
-define PatientGender: Patient.gender.value
-define PatientDateOfBirth: Patient.birthDate.value
-
-define PatientCoverageResource: singleton from (
-  [Coverage] coverage
-    // pull coverage resource id from the device request insurance extension
-    where ('Coverage/' + coverage.id) = ((device_request.extension ext where ext.url = 'http://build.fhir.org/ig/HL7/davinci-crd/STU3/ext-insurance.html')[0].value.reference.value))
-define PatientMedicareId: "PatientCoverageResource".subscriberId.value
-
 // coverage requirement info
 define OsaDiagnosis:
   if exists(Confirmed(ActiveOrRecurring([Condition: "OSA_Codes"]))) then 'OSA' else 'null'

--- a/server/src/main/jib/smartAppFhirArtifacts/home-oxygen-questionnaire_2.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/home-oxygen-questionnaire_2.json
@@ -19,6 +19,12 @@
       "valueReference": {
         "reference": "urn:hl7:davinci:crd:library-oxygen-therapy-prepopulate"
       }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/cqif-library",
+      "valueReference": {
+        "reference": "urn:hl7:davinci:crd:library-basic-patient-info-prepopulate"
+      }
     }
   ],
   "contained": [
@@ -64,7 +70,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientLastName"
+              "valueString": "\"BasicPatientInfo\".LastName"
             }
           ]
         },
@@ -76,7 +82,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientFirstName"
+              "valueString": "\"BasicPatientInfo\".FirstName"
             }
           ]
         },
@@ -88,7 +94,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientMiddleInitial"
+              "valueString": "\"BasicPatientInfo\".MiddleInitial"
             }
           ]
         },
@@ -100,7 +106,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientDateOfBirth"
+              "valueString": "\"BasicPatientInfo\".DateOfBirth"
             }
           ]
         },
@@ -115,7 +121,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientGender"
+              "valueString": "\"BasicPatientInfo\".Gender"
             }
           ]
         },
@@ -127,7 +133,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientMedicareId"
+              "valueString": "\"BasicPatientInfo\".MedicareId"
             }
           ]
         }
@@ -146,7 +152,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderLastName"
+              "valueString": "\"OxygenTherapy\".OrderingProviderLastName"
             }
           ]
         },
@@ -158,7 +164,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderFirstName"
+              "valueString": "\"OxygenTherapy\".OrderingProviderFirstName"
             }
           ]
         },
@@ -170,7 +176,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderMiddleInitial"
+              "valueString": "\"OxygenTherapy\".OrderingProviderMiddleInitial"
             }
           ]
         },
@@ -182,7 +188,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderNPI"
+              "valueString": "\"OxygenTherapy\".OrderingProviderNPI"
             }
           ]
         },
@@ -194,7 +200,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "Today"
+              "valueString": "\"OxygenTherapy\".Today"
             }
           ]
         }
@@ -261,7 +267,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "RelevantDiagnoses"
+              "valueString": "\"OxygenTherapy\".RelevantDiagnoses"
             }
           ]
         },
@@ -273,7 +279,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "ArterialOxygenSaturation"
+              "valueString": "\"OxygenTherapy\".ArterialOxygenSaturation"
             }
           ]
         },
@@ -285,7 +291,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "ArterialPartialPressureOfOxygen"
+              "valueString": "\"OxygenTherapy\".ArterialPartialPressureOfOxygen"
             }
           ]
         },
@@ -297,7 +303,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "ArterialOxygenSaturationExercise"
+              "valueString": "\"OxygenTherapy\".ArterialOxygenSaturationExercise"
             }
           ]
         },
@@ -327,7 +333,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientMobile"
+              "valueString": "\"OxygenTherapy\".PatientMobile"
             }
           ]
         },
@@ -378,7 +384,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientHasHematocritThatIsGreaterThanThreshold"
+              "valueString": "\"OxygenTherapy\".PatientHasHematocritThatIsGreaterThanThreshold"
             }
           ]
         },
@@ -396,7 +402,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "HematocritThatIsGreaterThanThreshold"
+              "valueString": "\"OxygenTherapy\".HematocritThatIsGreaterThanThreshold"
             }
           ]
         }
@@ -415,7 +421,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "Today"
+              "valueString": "\"OxygenTherapy\".Today"
             }
           ]
         },
@@ -515,7 +521,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "DeviceRequestDescription"
+              "valueString": "\"OxygenTherapy\".DeviceRequestDescription"
             }
           ]
         },
@@ -527,7 +533,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "DeviceRequestedIsPortable"
+              "valueString": "\"OxygenTherapy\".DeviceRequestedIsPortable"
             }
           ]
         },

--- a/server/src/main/jib/smartAppFhirArtifacts/library-basic-patient-info-prepopulate.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/library-basic-patient-info-prepopulate.json
@@ -11,6 +11,14 @@
       }
     ]
   },
+  "relatedArtifact": [
+    {
+      "type": "depends-on",
+      "resource": {
+        "reference": "urn:hl7:davinci:crd:library-fhir-helpers"
+      }
+    }
+  ],
   "content": [
     {
       "contentType": "application/elm+json",

--- a/server/src/main/jib/smartAppFhirArtifacts/library-basic-patient-info-prepopulate.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/library-basic-patient-info-prepopulate.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Library",
+  "id": "urn:hl7:davinci:crd:library-basic-patient-info",
+  "version": "0.0.1",
+  "title": "Basic Patient Info",
+  "status": "draft",
+  "type": {
+    "coding": [
+      {
+        "code": "logic-library"
+      }
+    ]
+  },
+  "content": [
+    {
+      "contentType": "application/elm+json",
+      "url": "urn:hl7:davinci:crd:BasicPatientInfoPrepopulate.cql"
+    }
+  ]
+}

--- a/server/src/main/jib/smartAppFhirArtifacts/library-oxygen-therapy-prepopulate.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/library-oxygen-therapy-prepopulate.json
@@ -19,6 +19,19 @@
       }
     }
   ],
+  "dataRequirement": [
+    {
+      "type": "Condition",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSetReference": {
+            "reference": "urn:hl7:davinci:crd:valueset-copd"
+          }
+        }
+      ]
+    }
+  ],
   "content": [
     {
       "contentType": "application/elm+json",

--- a/server/src/main/jib/smartAppFhirArtifacts/library-oxygen-therapy-prepopulate.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/library-oxygen-therapy-prepopulate.json
@@ -22,7 +22,7 @@
   "content": [
     {
       "contentType": "application/elm+json",
-      "url": "urn:hl7:davinci:crd:OxygenTherapyPrepopulation.json"
+      "url": "urn:hl7:davinci:crd:OxygenTherapyPrepopulation.cql"
     }
   ]
 }

--- a/server/src/main/jib/smartAppFhirArtifacts/positive-airway-pressure-questionnaire.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/positive-airway-pressure-questionnaire.json
@@ -6,6 +6,12 @@
       "valueReference": {
         "reference": "urn:hl7:davinci:crd:library-positive-airway-pressure-prepopulate"
       }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/cqif-library",
+      "valueReference": {
+        "reference": "urn:hl7:davinci:crd:library-basic-patient-info-prepopulate"
+      }
     }
   ],
   "identifier": [
@@ -29,7 +35,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientLastName"
+              "valueString": "\"BasicPatientInfo\".LastName"
             }
           ],
           "linkId": "1.1",
@@ -41,7 +47,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientFirstName"
+              "valueString": "\"BasicPatientInfo\".FirstName"
             }
           ],
           "linkId": "1.2",
@@ -53,7 +59,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientMiddleInitial"
+              "valueString": "\"BasicPatientInfo\".MiddleInitial"
             }
           ],
           "linkId": "1.3",
@@ -65,7 +71,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientDateOfBirth"
+              "valueString": "\"BasicPatientInfo\".DateOfBirth"
             }
           ],
           "linkId": "1.4",
@@ -77,7 +83,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientGender"
+              "valueString": "\"BasicPatientInfo\".Gender"
             }
           ],
           "linkId": "1.5",
@@ -103,7 +109,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PatientMedicareId"
+              "valueString": "\"BasicPatientInfo\".MedicareId"
             }
           ],
           "linkId": "1.6",
@@ -122,7 +128,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderLastName"
+              "valueString": "\"PositiveAirwayPressureDevice\".OrderingProviderLastName"
             }
           ],
           "linkId": "2.1",
@@ -134,7 +140,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderFirstName"
+              "valueString": "\"PositiveAirwayPressureDevice\".OrderingProviderFirstName"
             }
           ],
           "linkId": "2.2",
@@ -146,7 +152,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderMiddleInitial"
+              "valueString": "\"PositiveAirwayPressureDevice\".OrderingProviderMiddleInitial"
             }
           ],
           "linkId": "2.3",
@@ -176,7 +182,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OsaDiagnosis"
+              "valueString": "\"PositiveAirwayPressureDevice\".OsaDiagnosis"
             }
           ],
           "linkId": "4.1",
@@ -207,7 +213,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OtherDiagnoses"
+              "valueString": "\"PositiveAirwayPressureDevice\".OtherDiagnoses"
             }
           ],
           "linkId": "4.3",
@@ -302,7 +308,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "PapDeviceRequested"
+              "valueString": "\"PositiveAirwayPressureDevice\".PapDeviceRequested"
             }
           ],
           "linkId": "7.2",
@@ -338,7 +344,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderFullName"
+              "valueString": "\"PositiveAirwayPressureDevice\".OrderingProviderFullName"
             }
           ],
           "linkId": "9.2",
@@ -350,7 +356,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "Today"
+              "valueString": "\"PositiveAirwayPressureDevice\".Today"
             }
           ],
           "linkId": "9.3",
@@ -362,7 +368,7 @@
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqif-calculatedValue",
-              "valueString": "OrderingProviderNPI"
+              "valueString": "\"PositiveAirwayPressureDevice\".OrderingProviderNPI"
             }
           ],
           "linkId": "9.4",

--- a/server/src/main/jib/smartAppFhirArtifacts/valueset-copd.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/valueset-copd.json
@@ -1,0 +1,37 @@
+{
+  "resourceType": "ValueSet",
+  "id": "urn:hl7:davinci:crd:valueset-copd",
+  "title": "COPD",
+  "status": "draft",
+  "version": "0.0.1",
+  "expansion": {
+    "identifier": "urn:hl7:davinci:crd:valueset-copd",
+    "timestamp": "2019-11-04T17:45:07Z",
+    "contains": [
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "version": "2020",
+        "code": "J44",
+        "display": "Other chronic obstructive pulmonary disease"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "version": "2020",
+        "code": "J44.0",
+        "display": "Chronic obstructive pulmonary disease with (acute) lower respiratory infection"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "version": "2020",
+        "code": "J44.1",
+        "display": "Chronic obstructive pulmonary disease with (acute) exacerbation"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "version": "2020",
+        "code": "J44.9",
+        "display": "Chronic obstructive pulmonary disease, unspecified"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Moved basic patient info out of the two existing pre-population libraries
- Created shared BasicPatientInfo library
- Made both questionnaires reference the basic patient info library
- Updated CQL result references in questionnaires to reference library name and statement name
- Started ValueSet refactor by moving COPD codes in OxygenTherapy to an "expanded" FHIR ValueSet.
- Added dataRequirement to the oxygen therapy library to reference the ValueSet
