### PR TITLE
[435] Add order-select hook to CRD - Connectathon

### DIFF
--- a/resources/src/main/java/org/cdshooks/Hook.java
+++ b/resources/src/main/java/org/cdshooks/Hook.java
@@ -6,7 +6,9 @@ import java.io.IOException;
 
 public enum Hook {
 
-  ORDER_REVIEW("order-review"), MEDICATION_PRESCRIBE("medication-prescribe");
+  ORDER_REVIEW("order-review"),
+  MEDICATION_PRESCRIBE("medication-prescribe"),
+  ORDER_SELECT("order-select");
 
   private String value;
 

--- a/resources/src/main/java/org/hl7/davinci/r4/crdhook/CrdPrefetch.java
+++ b/resources/src/main/java/org/hl7/davinci/r4/crdhook/CrdPrefetch.java
@@ -8,8 +8,8 @@ import org.hl7.fhir.r4.model.*;
 
 /**
  * Class that supports the representation of prefetch information in a CDS Hook request.
- * It appears that for CRD, prefetch information will be the same, regardless of hook type (order-review or
- * medication-prescribe).
+ * It appears that for CRD, prefetch information will be the same, regardless of hook type (order-review,
+ * medication-prescribe, or order-select).
  */
 public class CrdPrefetch {
 
@@ -33,6 +33,14 @@ public class CrdPrefetch {
   @JsonDeserialize(using = JacksonBundleDeserializer.class)
   private Bundle supplyRequestBundle;
 
+  @JsonSerialize(using = JacksonHapiSerializer.class)
+  @JsonDeserialize(using = JacksonBundleDeserializer.class)
+  private Bundle appointmentBundle;
+
+  @JsonSerialize(using = JacksonHapiSerializer.class)
+  @JsonDeserialize(using = JacksonBundleDeserializer.class)
+  private Bundle encounterBundle;
+
   public Bundle getDeviceRequestBundle() {
     return deviceRequestBundle;
   }
@@ -45,9 +53,7 @@ public class CrdPrefetch {
     return medicationRequestBundle;
   }
 
-  public void setMedicationRequestBundle(Bundle medicationRequestBundle) {
-    this.medicationRequestBundle = medicationRequestBundle;
-  }
+  public void setMedicationRequestBundle(Bundle medicationRequestBundle) { this.medicationRequestBundle = medicationRequestBundle; }
 
   public Bundle getNutritionOrderBundle() {
     return nutritionOrderBundle;
@@ -72,4 +78,12 @@ public class CrdPrefetch {
   public void setSupplyRequestBundle(Bundle supplyRequestBundle) {
     this.supplyRequestBundle = supplyRequestBundle;
   }
+
+  public Bundle getAppointmentBundle() { return appointmentBundle; }
+
+  public void setAppointmentBundle(Bundle appointmentBundle) { this.appointmentBundle = appointmentBundle; }
+
+  public Bundle getEncounterBundle() { return encounterBundle; }
+
+  public void setEncounterBundle(Bundle encounterBundle) { this.encounterBundle = encounterBundle; }
 }

--- a/resources/src/main/java/org/hl7/davinci/r4/crdhook/CrdPrefetchTemplateElements.java
+++ b/resources/src/main/java/org/hl7/davinci/r4/crdhook/CrdPrefetchTemplateElements.java
@@ -73,4 +73,24 @@ public class CrdPrefetchTemplateElements {
           + "&_include=SupplyRequest:insurance:Coverage",
       Bundle.class);
 
+  public static final PrefetchTemplateElement APPOINTMENT_BUNDLE = new PrefetchTemplateElement(
+      "appointmentBundle",
+      "Appointment?_id={{context.appointments.Appointment.id}}"
+          + "&_include=Appointment:patient"
+          + "&_include=Appointment:practitioner:PractitionerRole"
+          + "&_include:iterate=PractitionerRole:organization"
+          + "&_include:iterate=PractitionerRole:practitioner"
+          + "&_include=Appointment:location"
+          + "&_include=Appointment:insurance:Coverage",
+      Bundle.class);
+
+  public static final PrefetchTemplateElement ENCOUNTER_BUNDLE = new PrefetchTemplateElement(
+      "encounterBundle",
+      "Encounter?_id={{context.encounterId}}"
+          + "&_include=Encounter:patient&_include=Encounter:service-provider"
+          + "&_include=Encounter:practitioner"
+          + "&_include=Encounter:location"
+          + "&_include=Encounter:insurance:Coverage",
+      Bundle.class);
+
 }

--- a/resources/src/main/java/org/hl7/davinci/r4/crdhook/orderselect/OrderSelectContext.java
+++ b/resources/src/main/java/org/hl7/davinci/r4/crdhook/orderselect/OrderSelectContext.java
@@ -1,0 +1,61 @@
+package org.hl7.davinci.r4.crdhook.orderselect;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.hl7.davinci.r4.JacksonBundleDeserializer;
+import org.hl7.davinci.r4.JacksonHapiSerializer;
+import org.hl7.davinci.r4.crdhook.ServiceContext;
+import org.hl7.fhir.r4.model.*;
+
+import javax.validation.constraints.NotNull;
+
+public class OrderSelectContext extends ServiceContext {
+
+  /** The FHIR Patient.id of the current patient in context. REQUIRED */
+  @NotNull
+  private String patientId;
+
+  /** The FHIR Encounter.id of the current encounter in context. OPTIONAL */
+  private String encounterId;
+
+  /** The FHIR id of the newly selected order(s). The selections field references FHIR resources
+   * in the draftOrders Bundle. For example, MedicationRequest/103. */
+  private String[] selections;
+
+  /**
+   * STU3 - FHIR Bundle of MedicationRequest, ReferralRequest, ProcedureRequest, NutritionOrder,
+   * VisionPrescription. REQUIRED
+   */
+  @JsonSerialize(using = JacksonHapiSerializer.class)
+  @JsonDeserialize(using = JacksonBundleDeserializer.class)
+  private Bundle draftOrders;
+
+  public String getPatientId() {
+    return patientId;
+  }
+
+  public void setPatientId(String patientId) {
+    this.patientId = patientId;
+  }
+
+  public String getEncounterId() {
+    return encounterId;
+  }
+
+  public void setEncounterId(String encounterId) {
+    this.encounterId = encounterId;
+  }
+
+  public String[] getSelections() { return selections; }
+
+  public void setSelections(String[] selections) { this.selections = selections; }
+
+  public Bundle getDraftOrders() {
+    return draftOrders;
+  }
+
+  public void setDraftOrders(Bundle draftOrders) {
+    this.draftOrders = draftOrders;
+  }
+
+}

--- a/resources/src/main/java/org/hl7/davinci/r4/crdhook/orderselect/OrderSelectRequest.java
+++ b/resources/src/main/java/org/hl7/davinci/r4/crdhook/orderselect/OrderSelectRequest.java
@@ -1,0 +1,37 @@
+package org.hl7.davinci.r4.crdhook.orderselect;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.cdshooks.CdsRequest;
+import org.hl7.davinci.r4.Utilities;
+import org.hl7.davinci.r4.crdhook.CrdPrefetch;
+
+import java.util.HashMap;
+
+public class OrderSelectRequest extends CdsRequest<CrdPrefetch, OrderSelectContext> {
+
+  private HashMap<String, Object> mapForPrefetchTemplates = null;
+
+  /**
+   * Gets the data from the context to put into the prefetch token.
+   * @return a map of prefetch attributes to their values
+   */
+  @JsonIgnore
+  public Object getDataForPrefetchToken() {
+    if (mapForPrefetchTemplates != null) {
+      return mapForPrefetchTemplates;
+    }
+    mapForPrefetchTemplates = new HashMap<>();
+    mapForPrefetchTemplates.put("user", this.getUser());
+
+    HashMap<String, Object> contextMap = new HashMap<>();
+    contextMap.put("patientId", getContext().getPatientId());
+    contextMap.put("encounterId", getContext().getEncounterId());
+    contextMap.put("selections", getContext().getSelections());
+    contextMap.put("draftOrders", Utilities.bundleAsHashmap(getContext().getDraftOrders()));
+    mapForPrefetchTemplates.put("context", contextMap);
+
+    return mapForPrefetchTemplates;
+  }
+
+
+}

--- a/resources/src/main/java/org/hl7/davinci/stu3/crdhook/CrdPrefetch.java
+++ b/resources/src/main/java/org/hl7/davinci/stu3/crdhook/CrdPrefetch.java
@@ -8,8 +8,8 @@ import org.hl7.fhir.dstu3.model.Bundle;
 
 /**
  * Class that supports the representation of prefetch information in a CDS Hook request.
- * It appears that for CRD, prefetch information will be the same, regardless of hook type (order-review or
- * medication-prescribe).
+ * It appears that for CRD, prefetch information will be the same, regardless of hook type (order-review,
+ * medication-prescribe, or order-select).
  */
 public class CrdPrefetch {
   @JsonSerialize(using = JacksonHapiSerializer.class)
@@ -30,11 +30,23 @@ public class CrdPrefetch {
 
   @JsonSerialize(using = JacksonHapiSerializer.class)
   @JsonDeserialize(using = JacksonBundleDeserializer.class)
-  private Bundle referralRequest;
+  private Bundle referralRequestBundle;
 
   @JsonSerialize(using = JacksonHapiSerializer.class)
   @JsonDeserialize(using = JacksonBundleDeserializer.class)
   private Bundle supplyRequestBundle;
+
+  @JsonSerialize(using = JacksonHapiSerializer.class)
+  @JsonDeserialize(using = JacksonBundleDeserializer.class)
+  private Bundle visionPrescriptionBundle;
+
+  @JsonSerialize(using = JacksonHapiSerializer.class)
+  @JsonDeserialize(using = JacksonBundleDeserializer.class)
+  private Bundle appointmentBundle;
+
+  @JsonSerialize(using = JacksonHapiSerializer.class)
+  @JsonDeserialize(using = JacksonBundleDeserializer.class)
+  private Bundle encounterBundle;
 
   public Bundle getDeviceRequestBundle() {
     return deviceRequestBundle;
@@ -48,9 +60,7 @@ public class CrdPrefetch {
     return medicationRequestBundle;
   }
 
-  public void setMedicationRequestBundle(Bundle medicationRequestBundle) {
-    this.medicationRequestBundle = medicationRequestBundle;
-  }
+  public void setMedicationRequestBundle(Bundle medicationRequestBundle) { this.medicationRequestBundle = medicationRequestBundle; }
 
   public Bundle getNutritionOrderBundle() {
     return nutritionOrderBundle;
@@ -64,17 +74,13 @@ public class CrdPrefetch {
     return procedureRequestBundle;
   }
 
-  public void setProcedureRequestBundle(Bundle procedureRequestBundle) {
-    this.procedureRequestBundle = procedureRequestBundle;
+  public void setProcedureRequestBundle(Bundle procedureRequestBundle) { this.procedureRequestBundle = procedureRequestBundle; }
+
+  public Bundle getReferralRequestBundle() {
+    return referralRequestBundle;
   }
 
-  public Bundle getReferralRequest() {
-    return referralRequest;
-  }
-
-  public void setReferralRequest(Bundle referralRequest) {
-    this.referralRequest = referralRequest;
-  }
+  public void setReferralRequestBundle(Bundle referralRequestBundle) { this.referralRequestBundle = referralRequestBundle; }
 
   public Bundle getSupplyRequestBundle() {
     return supplyRequestBundle;
@@ -84,4 +90,15 @@ public class CrdPrefetch {
     this.supplyRequestBundle = supplyRequestBundle;
   }
 
+  public Bundle getVisionPrescriptionBundle() { return visionPrescriptionBundle; }
+
+  public void setVisionPrescriptionBundle(Bundle visionPrescriptionBundle) { this.visionPrescriptionBundle = visionPrescriptionBundle; }
+
+  public Bundle getAppointmentBundle() { return appointmentBundle; }
+
+  public void setAppointmentBundle(Bundle appointmentBundle) { this.appointmentBundle = appointmentBundle; }
+
+  public Bundle getEncounterBundle() { return encounterBundle; }
+
+  public void setEncounterBundle(Bundle encounterBundle) { this.encounterBundle = encounterBundle; }
 }

--- a/resources/src/main/java/org/hl7/davinci/stu3/crdhook/CrdPrefetchTemplateElements.java
+++ b/resources/src/main/java/org/hl7/davinci/stu3/crdhook/CrdPrefetchTemplateElements.java
@@ -52,7 +52,7 @@ public class CrdPrefetchTemplateElements {
       Bundle.class);
 
   public static final PrefetchTemplateElement REFERRAL_REQUEST_BUNDLE = new PrefetchTemplateElement(
-      "referralRequest",
+      "referralRequestBundle",
       "ReferralRequest?_id={{context.orders.ReferralRequest.id}}"
           + "&_include=ReferralRequest:patient"
           + "&_include=ReferralRequest:recipient"
@@ -69,6 +69,32 @@ public class CrdPrefetchTemplateElements {
           + "&_include=SupplyRequest:requester:Practitioner"
           + "&_include=SupplyRequest:requester:Organization"
           + "&_include=SupplyRequest:insurance:Coverage",
+      Bundle.class);
+
+  public static final PrefetchTemplateElement VISION_PRESCRIPTION_BUNDLE = new PrefetchTemplateElement(
+      "visionPrescriptionBundle",
+      "VisionPrescription?_id={{context.draftOrders.VisionPrescription.id}}"
+          + "&_include=VisionPrescription:patient"
+          + "&_include=VisionPrescription:prescriber"
+          + "&_include=VisionPrescription:insurance:Coverage",
+      Bundle.class);
+
+  public static final PrefetchTemplateElement APPOINTMENT_BUNDLE = new PrefetchTemplateElement(
+      "appointmentBundle",
+      "Appointment?_id={{context.appointments.Appointment.id}}"
+          + "&_include=Appointment:patient, Appointment:practitioner"
+          + "&_include=Appointment:location"
+          + "&_include=Appointment:insurance:Coverage",
+      Bundle.class);
+
+  public static final PrefetchTemplateElement ENCOUNTER_BUNDLE = new PrefetchTemplateElement(
+      "encounterBundle",
+      "Encounter?_id={{context.encounterId}}"
+          + "&_include=Encounter:patient"
+          + "&_include=Encounter:service-provider"
+          + "&_include=Encounter:practitioner"
+          + "&_include=Encounter:location"
+          + "&_include=Encounter:insurance:Coverage",
       Bundle.class);
 
 }

--- a/resources/src/main/java/org/hl7/davinci/stu3/crdhook/orderselect/OrderSelectContext.java
+++ b/resources/src/main/java/org/hl7/davinci/stu3/crdhook/orderselect/OrderSelectContext.java
@@ -1,0 +1,61 @@
+package org.hl7.davinci.stu3.crdhook.orderselect;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.NotNull;
+import org.hl7.davinci.stu3.JacksonBundleDeserializer;
+import org.hl7.davinci.stu3.JacksonHapiSerializer;
+import org.hl7.davinci.stu3.crdhook.ServiceContext;
+import org.hl7.fhir.dstu3.model.Bundle;
+
+public class OrderSelectContext extends ServiceContext {
+
+  /** The FHIR Patient.id of the current patient in context. REQUIRED */
+  @NotNull
+  private String patientId;
+
+  /** The FHIR Encounter.id of the current encounter in context. OPTIONAL */
+  private String encounterId;
+
+  /** The FHIR id of the newly selected order(s). The selections field references FHIR resources
+   * in the draftOrders Bundle. For example, MedicationRequest/103. */
+  private String[] selections;
+
+
+  /**
+   * STU3 - FHIR Bundle of MedicationRequest, ReferralRequest, ProcedureRequest, NutritionOrder,
+   * VisionPrescription. REQUIRED
+   */
+  @JsonSerialize(using = JacksonHapiSerializer.class)
+  @JsonDeserialize(using = JacksonBundleDeserializer.class)
+  private Bundle draftOrders;
+
+  public String getPatientId() {
+    return patientId;
+  }
+
+  public void setPatientId(String patientId) {
+    this.patientId = patientId;
+  }
+
+  public String getEncounterId() {
+    return encounterId;
+  }
+
+  public void setEncounterId(String encounterId) {
+    this.encounterId = encounterId;
+  }
+
+  public String[] getSelections() { return selections; }
+
+  public void setSelections(String[] selections) { this.selections = selections; }
+
+  public Bundle getDraftOrders() {
+    return draftOrders;
+  }
+
+  public void setDraftOrders(Bundle draftOrders) {
+    this.draftOrders = draftOrders;
+  }
+
+}

--- a/resources/src/main/java/org/hl7/davinci/stu3/crdhook/orderselect/OrderSelectRequest.java
+++ b/resources/src/main/java/org/hl7/davinci/stu3/crdhook/orderselect/OrderSelectRequest.java
@@ -1,0 +1,38 @@
+package org.hl7.davinci.stu3.crdhook.orderselect;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.cdshooks.CdsRequest;
+import org.hl7.davinci.stu3.Utilities;
+import org.hl7.davinci.stu3.crdhook.CrdPrefetch;
+
+import java.util.HashMap;
+
+public class OrderSelectRequest extends CdsRequest<CrdPrefetch, OrderSelectContext> {
+
+  private HashMap<String, Object> mapForPrefetchTemplates = null;
+
+  /**
+   * Gets the data from the context to put into the prefetch token.
+   * @return a map of prefetch attributes to their values
+   */
+  @JsonIgnore
+  public Object getDataForPrefetchToken() {
+    if (mapForPrefetchTemplates != null) {
+      return mapForPrefetchTemplates;
+    }
+    mapForPrefetchTemplates = new HashMap<>();
+    mapForPrefetchTemplates.put("user", this.getUser());
+
+    HashMap<String, Object> contextMap = new HashMap<>();
+    contextMap.put("patientId", getContext().getPatientId());
+    contextMap.put("encounterId", getContext().getEncounterId());
+    contextMap.put("selections", getContext().getSelections());
+    contextMap.put("draftOrders", Utilities.bundleAsHashmap(getContext().getDraftOrders()));
+    mapForPrefetchTemplates.put("context", contextMap);
+
+    return mapForPrefetchTemplates;
+  }
+
+
+}
+

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderSelectService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/OrderSelectService.java
@@ -1,0 +1,140 @@
+package org.hl7.davinci.endpoint.cdshooks.services.crd.r4;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.cdshooks.Hook;
+import org.hl7.davinci.PrefetchTemplateElement;
+import org.hl7.davinci.RequestIncompleteException;
+import org.hl7.davinci.endpoint.cdshooks.services.crd.CdsService;
+import org.hl7.davinci.endpoint.cql.r4.CqlExecutionContextBuilder;
+import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleCriteria;
+import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleFinder;
+import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleQuery;
+import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleResult;
+import org.hl7.davinci.endpoint.cql.bundle.CqlBundle;
+import org.hl7.davinci.endpoint.database.CoverageRequirementRule;
+import org.hl7.davinci.r4.FhirComponents;
+import org.hl7.davinci.r4.Utilities;
+import org.hl7.davinci.r4.crdhook.CrdPrefetchTemplateElements;
+import org.hl7.davinci.r4.crdhook.orderselect.OrderSelectRequest;
+import org.hl7.fhir.r4.model.Bundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.opencds.cqf.cql.execution.Context;
+
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Coverage;
+import org.hl7.fhir.r4.model.DeviceRequest;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Resource;
+
+
+@Component("r4_OrderSelectService")
+public class OrderSelectService extends CdsService<OrderSelectRequest> {
+
+  public static final String ID = "order-select-crd";
+  public static final String TITLE = "order-select Coverage Requirements Discovery";
+  public static final Hook HOOK = Hook.ORDER_SELECT;
+  public static final String DESCRIPTION =
+      "Get information regarding the coverage requirements for durable medical equipment";
+  public static final List<PrefetchTemplateElement> PREFETCH_ELEMENTS = Arrays.asList(
+      CrdPrefetchTemplateElements.DEVICE_REQUEST_BUNDLE,
+      CrdPrefetchTemplateElements.SUPPLY_REQUEST_BUNDLE,
+      CrdPrefetchTemplateElements.NUTRITION_ORDER_BUNDLE,
+      CrdPrefetchTemplateElements.MEDICATION_REQUEST_BUNDLE,
+      CrdPrefetchTemplateElements.SERVICE_REQUEST_BUNDLE);
+  public static final FhirComponents FHIRCOMPONENTS = new FhirComponents();
+  static final Logger logger = LoggerFactory.getLogger(OrderSelectService.class);
+
+  public OrderSelectService() { super(ID, HOOK, TITLE, DESCRIPTION, PREFETCH_ELEMENTS, FHIRCOMPONENTS); }
+
+  @Override
+  public List<CoverageRequirementRuleResult> createCqlExecutionContexts(OrderSelectRequest orderSelectRequest, CoverageRequirementRuleFinder ruleFinder) {
+    // Note only device requests are currently supported, but you could follow this model to add
+    // the others (e.g. supply request), just make sure we have at least one bundle
+
+    // Note: the selections array is currently ignored, all of the draftOrders are processed, not just those selected.
+    List<DeviceRequest> deviceRequestList = extractDeviceRequests(orderSelectRequest);
+    if (deviceRequestList.isEmpty()) {
+      throw RequestIncompleteException.NoSupportedBundlesFound();
+    }
+
+    List<CoverageRequirementRuleResult> results = new ArrayList<>();
+    results.addAll(getDeviceRequestExecutionContexts(deviceRequestList, ruleFinder));
+
+    return results;
+  }
+
+  private Context createCqlExecutionContext(CqlBundle cqlPackage, DeviceRequest deviceRequest) {
+    Patient patient = (Patient) deviceRequest.getSubject().getResource();
+    HashMap<String,Resource> cqlParams = new HashMap<>();
+    cqlParams.put("Patient", patient);
+    cqlParams.put("device_request", deviceRequest);
+    return CqlExecutionContextBuilder.getExecutionContext(cqlPackage, cqlParams);
+  }
+
+  private List<CoverageRequirementRuleResult> getDeviceRequestExecutionContexts(List<DeviceRequest> deviceRequestList, CoverageRequirementRuleFinder ruleFinder) {
+    List<CoverageRequirementRuleResult> results = new ArrayList<>();
+    for (DeviceRequest deviceRequest : deviceRequestList) {
+      List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(deviceRequest);
+      for (CoverageRequirementRuleCriteria criteria : criteriaList) {
+        CoverageRequirementRuleQuery query = new CoverageRequirementRuleQuery(ruleFinder, criteria);
+        query.execute();
+        for (CoverageRequirementRule rule: query.getResponse()) {
+          CoverageRequirementRuleResult result = new CoverageRequirementRuleResult();
+          result.setCriteria(criteria);
+          try {
+            result.setContext(createCqlExecutionContext(rule.getCqlBundle(), deviceRequest));
+            results.add(result);
+          } catch (Exception e) {
+            logger.info("r4/OrderSelectService::getDeviceRequestExecutionContexts: failed processing cql bundle: " + e.getMessage());
+          }
+        }
+      }
+    }
+    return results;
+  }
+
+  private List<DeviceRequest> extractDeviceRequests(OrderSelectRequest orderSelectRequest) {
+    Bundle deviceRequestBundle = orderSelectRequest.getPrefetch().getDeviceRequestBundle();
+    List<DeviceRequest> deviceRequestList = Utilities
+        .getResourcesOfTypeFromBundle(DeviceRequest.class, deviceRequestBundle);
+    return deviceRequestList;
+  }
+
+  private List<CoverageRequirementRuleCriteria> createCriteriaList(DeviceRequest deviceRequest) {
+    try {List<Coding> codings = deviceRequest.getCodeCodeableConcept().getCoding();
+      if (codings.size() > 0) {
+        logger.info("r4/OrderSelectService::createCriteriaList: code[0]: " + codings.get(0).getCode() + " - " + codings.get(0).getSystem());
+      } else {
+        logger.info("r4/OrderSelectService::createCriteriaList: empty codes list!");
+      }
+
+      List<Coverage> coverages = deviceRequest.getInsurance().stream()
+          .map(reference -> (Coverage) reference.getResource()).collect(Collectors.toList());
+      List<Organization> payors = Utilities.getPayors(coverages);
+      if (payors.size() > 0) {
+        logger.info("r4/OrderSelectService::createCriteriaList: payer[0]: " + payors.get(0).getName());
+      } else {
+        // default to CMS if no payer was provided
+        logger.info("r4/OrderSelectService::createCriteriaList: empty payers list, working around by adding CMS!");
+        Organization org = new Organization().setName("Centers for Medicare and Medicaid Services");
+        org.setId("75f39025-65db-43c8-9127-693cdf75e712");
+        payors.add(org);
+      }
+
+      List<CoverageRequirementRuleCriteria> criteriaList = CoverageRequirementRuleCriteria
+          .createQueriesFromR4(codings, payors);
+      return criteriaList;
+    } catch (Exception e) {
+      System.out.println(e);
+      throw new RequestIncompleteException("Unable to parse list of codes, codesystems, and payors from a device request.");
+    }
+  }
+
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/OrderSelectService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/stu3/OrderSelectService.java
@@ -1,0 +1,146 @@
+package org.hl7.davinci.endpoint.cdshooks.services.crd.stu3;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.cdshooks.Hook;
+import org.hl7.davinci.PrefetchTemplateElement;
+import org.hl7.davinci.RequestIncompleteException;
+import org.hl7.davinci.endpoint.cdshooks.services.crd.CdsService;
+import org.hl7.davinci.endpoint.cql.bundle.CqlBundle;
+import org.hl7.davinci.endpoint.cql.stu3.CqlExecutionContextBuilder;
+import org.hl7.davinci.endpoint.database.CoverageRequirementRule;
+import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleCriteria;
+import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleFinder;
+import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleQuery;
+import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleResult;
+import org.hl7.davinci.stu3.FhirComponents;
+import org.hl7.davinci.stu3.Utilities;
+import org.hl7.davinci.stu3.crdhook.CrdPrefetchTemplateElements;
+import org.hl7.davinci.stu3.crdhook.orderselect.OrderSelectRequest;
+import org.hl7.davinci.stu3.fhirresources.DaVinciDeviceRequest;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.Coverage;
+import org.hl7.fhir.dstu3.model.Organization;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Resource;
+import org.opencds.cqf.cql.execution.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+
+@Component("stu3_OrderSelectService")
+public class OrderSelectService extends CdsService<OrderSelectRequest>  {
+
+  public static final String ID = "order-select-crd";
+  public static final String TITLE = "order-select Coverage Requirements Discovery";
+  public static final Hook HOOK = Hook.ORDER_SELECT;
+  public static final String DESCRIPTION =
+      "Get information regarding the coverage requirements for durable medical equipment";
+  static final Logger logger = LoggerFactory.getLogger(OrderSelectService.class);
+  public static final FhirComponents FHIRCOMPONENTS = new FhirComponents();
+  public static final List<PrefetchTemplateElement> PREFETCH_ELEMENTS = Arrays.asList(
+        CrdPrefetchTemplateElements.DEVICE_REQUEST_BUNDLE,
+        CrdPrefetchTemplateElements.SUPPLY_REQUEST_BUNDLE,
+        CrdPrefetchTemplateElements.NUTRITION_ORDER_BUNDLE,
+        CrdPrefetchTemplateElements.MEDICATION_REQUEST_BUNDLE,
+        CrdPrefetchTemplateElements.PROCEDURE_REQUEST_BUNDLE,
+        CrdPrefetchTemplateElements.REFERRAL_REQUEST_BUNDLE,
+        CrdPrefetchTemplateElements.VISION_PRESCRIPTION_BUNDLE
+    );
+
+  public OrderSelectService() {
+    super(ID, HOOK, TITLE, DESCRIPTION, PREFETCH_ELEMENTS, FHIRCOMPONENTS);
+  }
+
+  @Override
+  public List<CoverageRequirementRuleResult> createCqlExecutionContexts(OrderSelectRequest orderSelectRequest, CoverageRequirementRuleFinder ruleFinder) {
+
+    // Note only device requests are currently supported, but you could follow this model to add
+    // the others (e.g. supply request), just make sure we have at least one bundle
+
+    // Note: the selections array is currently ignored, all of the draftOrders are processed, not just those selected.
+    List<DaVinciDeviceRequest> deviceRequestList = extractDeviceRequests(orderSelectRequest);
+    if (deviceRequestList.isEmpty()) {
+      throw RequestIncompleteException.NoSupportedBundlesFound();
+    }
+
+    List<CoverageRequirementRuleResult> results = new ArrayList<>();
+    results.addAll(getDeviceRequestExecutionContexts(deviceRequestList, ruleFinder));
+
+    return results;
+  }
+
+  private Context createCqlExecutionContext(CqlBundle cqlPackage, DaVinciDeviceRequest deviceRequest) {
+    Patient patient = (Patient) deviceRequest.getSubject().getResource();
+    HashMap<String,Resource> cqlParams = new HashMap<>();
+    cqlParams.put("Patient", patient);
+    cqlParams.put("device_request", deviceRequest);
+    return CqlExecutionContextBuilder.getExecutionContext(cqlPackage, cqlParams);
+  }
+
+  private List<CoverageRequirementRuleResult> getDeviceRequestExecutionContexts(List<DaVinciDeviceRequest> deviceRequestList, CoverageRequirementRuleFinder ruleFinder) {
+    List<CoverageRequirementRuleResult> results = new ArrayList<>();
+    for (DaVinciDeviceRequest deviceRequest : deviceRequestList) {
+      List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(deviceRequest);
+      for (CoverageRequirementRuleCriteria criteria : criteriaList) {
+        CoverageRequirementRuleQuery query = new CoverageRequirementRuleQuery(ruleFinder, criteria);
+        query.execute();
+        for (CoverageRequirementRule rule: query.getResponse()) {
+          CoverageRequirementRuleResult result = new CoverageRequirementRuleResult();
+          result.setCriteria(criteria);
+          try {
+            result.setContext(createCqlExecutionContext(rule.getCqlBundle(), deviceRequest));
+            results.add(result);
+          } catch (Exception e) {
+            logger.info("stu3/OrderSelectRequest::getDeviceRequestExecutionContexts: failed processing cql bundle: " + e.getMessage());
+          }
+        }
+      }
+    }
+    return results;
+  }
+
+  private List<DaVinciDeviceRequest> extractDeviceRequests(OrderSelectRequest orderSelectRequest) {
+    Bundle deviceRequestBundle = orderSelectRequest.getPrefetch().getDeviceRequestBundle();
+    List<DaVinciDeviceRequest> deviceRequestList = Utilities
+        .getResourcesOfTypeFromBundle(DaVinciDeviceRequest.class, deviceRequestBundle);
+    return deviceRequestList;
+  }
+
+  private List<CoverageRequirementRuleCriteria> createCriteriaList(DaVinciDeviceRequest deviceRequest) {
+    try {
+      List<Coding> codings = deviceRequest.getCodeCodeableConcept().getCoding();
+      if (codings.size() > 0) {
+        logger.info("stu3/OrderSelectRequest::createCriteriaList: code[0]: " + codings.get(0).getCode() + " - " + codings.get(0).getSystem());
+      } else {
+        logger.info("stu3/OrderSelectRequest::createCriteriaList: empty codes list!");
+      }
+
+      List<Coverage> coverages = deviceRequest.getInsurance().stream()
+          .map(reference -> (Coverage) reference.getResource()).collect(Collectors.toList());
+      List<Organization> payors = Utilities.getPayors(coverages);
+      if (payors.size() > 0) {
+        logger.info("stu3/OrderSelectRequest::createCriteriaList: payer[0]: " + payors.get(0).getName());
+      } else {
+        // default to CMS if no payer was provided
+        logger.info("stu3/OrderSelectRequest::createCriteriaList: empty payers list, working around by adding CMS!");
+        Organization org = new Organization().setName("Centers for Medicare and Medicaid Services");
+        org.setId("75f39025-65db-43c8-9127-693cdf75e712");
+        payors.add(org);
+      }
+
+      List<CoverageRequirementRuleCriteria> criteriaList = CoverageRequirementRuleCriteria
+          .createQueriesFromStu3(codings, payors);
+      return criteriaList;
+    } catch (Exception e) {
+      System.out.println(e);
+      throw new RequestIncompleteException("Unable to parse list of codes, codesystems, and payors from a device request.");
+    }
+  }
+
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/controllers/r4/CdsHooksController.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/controllers/r4/CdsHooksController.java
@@ -7,9 +7,11 @@ import org.hl7.davinci.endpoint.Utils;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.CdsServiceInformation;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.r4.MedicationPrescribeService;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.r4.OrderReviewService;
+import org.hl7.davinci.endpoint.cdshooks.services.crd.r4.OrderSelectService;
 import org.hl7.davinci.r4.crdhook.CrdPrefetch;
 import org.hl7.davinci.r4.crdhook.medicationprescribe.MedicationPrescribeRequest;
 import org.hl7.davinci.r4.crdhook.orderreview.OrderReviewRequest;
+import org.hl7.davinci.r4.crdhook.orderselect.OrderSelectRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +32,7 @@ public class CdsHooksController {
 
   @Autowired private OrderReviewService orderReviewService;
   @Autowired private MedicationPrescribeService medicationPrescribeService;
+  @Autowired private OrderSelectService orderSelectService;
 
   /**
    * The FHIR r4 services discovery endpoint.
@@ -75,5 +78,21 @@ public class CdsHooksController {
       request.setPrefetch(new CrdPrefetch());
     }
     return medicationPrescribeService.handleRequest(request, Utils.getApplicationBaseUrl(httpServletRequest));
+  }
+
+  /**
+   * The coverage requirement discovery endpoint for the order select hook.
+   * @param request An order select triggered cds request
+   * @return The card response
+   */
+  @CrossOrigin
+  @PostMapping(value = FHIR_RELEASE + URL_BASE + "/" + OrderSelectService.ID,
+      consumes = "application/json;charset=UTF-8")
+  public CdsResponse handleOrderSelect(@Valid @RequestBody OrderSelectRequest request, final HttpServletRequest httpServletRequest) {
+    logger.info("r4/handleOrderSelect");
+    if (request.getPrefetch() == null) {
+      request.setPrefetch(new CrdPrefetch());
+    }
+    return orderSelectService.handleRequest(request, Utils.getApplicationBaseUrl(httpServletRequest));
   }
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/controllers/stu3/CdsHooksController.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/controllers/stu3/CdsHooksController.java
@@ -7,9 +7,11 @@ import org.hl7.davinci.endpoint.Utils;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.CdsServiceInformation;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.stu3.MedicationPrescribeService;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.stu3.OrderReviewService;
+import org.hl7.davinci.endpoint.cdshooks.services.crd.stu3.OrderSelectService;
 import org.hl7.davinci.stu3.crdhook.CrdPrefetch;
 import org.hl7.davinci.stu3.crdhook.medicationprescribe.MedicationPrescribeRequest;
 import org.hl7.davinci.stu3.crdhook.orderreview.OrderReviewRequest;
+import org.hl7.davinci.stu3.crdhook.orderselect.OrderSelectRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +32,7 @@ public class CdsHooksController {
 
   @Autowired private OrderReviewService orderReviewService;
   @Autowired private MedicationPrescribeService medicationPrescribeService;
+  @Autowired private OrderSelectService orderSelectService;
 
   /**
    * The FHIR STU3 services discovery endpoint.
@@ -78,4 +81,21 @@ public class CdsHooksController {
     }
     return medicationPrescribeService.handleRequest(request, Utils.getApplicationBaseUrl(httpServletRequest));
   }
+
+  /**
+   * The coverage requirement discovery endpoint for the order select hook.
+   * @param request An order select triggered cds request
+   * @return The card response
+   */
+  @CrossOrigin
+  @PostMapping(value = FHIR_RELEASE + URL_BASE + "/" + OrderSelectService.ID,
+      consumes = "application/json;charset=UTF-8")
+  public CdsResponse handleOrderSelect(@Valid @RequestBody OrderSelectRequest request, final HttpServletRequest httpServletRequest) {
+    logger.info("r4/handleOrderSelect");
+    if (request.getPrefetch() == null) {
+      request.setPrefetch(new CrdPrefetch());
+    }
+    return orderSelectService.handleRequest(request, Utils.getApplicationBaseUrl(httpServletRequest));
+  }
 }
+


### PR DESCRIPTION
The order-select hook will work for STU3 and R4. The selections field in the hook is ignored and all of the contained DeviceRequests are processed.