### PR TITLE
Connectathon 2020

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -240,6 +240,7 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     String appContext = "template=" + questionnaireUri + "&request=" + reqResourceId + "&filepath=";
     try {
       appContext = URLEncoder.encode(appContext, "UTF-8").toString();
+      appContext = "appContext=" + appContext;
     } catch (UnsupportedEncodingException e) {
       e.printStackTrace();
     }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -229,7 +229,8 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     appContextMap.put("template", questionnaireUri);
     appContextMap.put("request", reqResourceId);
     String filepath = "../../getfile/" + criteria.getQueryString();
-    String appContext = "template=" + questionnaireUri + "&request=" + reqResourceId + "&filepath=";
+
+    String appContext = "template$" + questionnaireUri + "&request$" + reqResourceId + "&filepath$";
     if (myConfig.getIncludeFilepathInAppContext()) {
       appContext = appContext + filepath;
     } else {

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -230,7 +230,7 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     appContextMap.put("request", reqResourceId);
     String filepath = "../../getfile/" + criteria.getQueryString();
 
-    String appContext = "template$" + questionnaireUri + "&request$" + reqResourceId + "&filepath$";
+    String appContext = "templateequals" + questionnaireUri + "&requestequals" + reqResourceId + "&filepathequals";
     if (myConfig.getIncludeFilepathInAppContext()) {
       appContext = appContext + filepath;
     } else {

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -240,7 +240,6 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     String appContext = "template=" + questionnaireUri + "&request=" + reqResourceId + "&filepath=";
     try {
       appContext = URLEncoder.encode(appContext, "UTF-8").toString();
-      appContext = "appContext=" + appContext;
     } catch (UnsupportedEncodingException e) {
       e.printStackTrace();
     }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -124,9 +124,6 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
    * @return The response from the server
    */
   public CdsResponse handleRequest(@Valid @RequestBody requestTypeT request, URL applicationBaseUrl) {
-    final String baseUrl =
-        ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
-    System.out.println(baseUrl);
     PrefetchHydrator prefetchHydrator = new PrefetchHydrator(this, request,
         this.fhirComponents);
     prefetchHydrator.hydrate();

--- a/server/src/main/jib/smartAppFhirArtifacts/library-oxygen-therapy-prepopulate.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/library-oxygen-therapy-prepopulate.json
@@ -35,7 +35,7 @@
   "content": [
     {
       "contentType": "application/elm+json",
-      "url": "urn:hl7:davinci:crd:OxygenTherapyPrepopulation.cql"
+      "url": "urn:hl7:davinci:crd:OxygenTherapyPrepopulation"
     }
   ]
 }

--- a/server/src/main/jib/smartAppFhirArtifacts/library-oxygen-therapy-prepopulate.json
+++ b/server/src/main/jib/smartAppFhirArtifacts/library-oxygen-therapy-prepopulate.json
@@ -35,7 +35,7 @@
   "content": [
     {
       "contentType": "application/elm+json",
-      "url": "urn:hl7:davinci:crd:OxygenTherapyPrepopulation"
+      "url": "urn:hl7:davinci:crd:OxygenTherapyPrepopulation.cql"
     }
   ]
 }


### PR DESCRIPTION
There's a change to the name of a file in the library for CQL retrieval, that might break things.  DMEERX-636 addresses this.  It's not imperative that we keep or remove the change, but it won't work with Epic's implementation without this change given the nature of the "bug".