### PR TITLE
Add a configuration switch to enable url encoding of the app context.

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/YamlConfig.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/YamlConfig.java
@@ -37,6 +37,8 @@ public class YamlConfig {
 
   private String localDbFhirArtifacts;
 
+  private boolean urlEncodeAppContext;
+
   public String getLocalDbFhirArtifacts() {
     return localDbFhirArtifacts;
   }
@@ -98,4 +100,8 @@ public class YamlConfig {
   public GitHubConfig getGitHubConfig() { return gitHubConfig; }
 
   public void setGitHubConfig(GitHubConfig gitHubConfig) { this.gitHubConfig = gitHubConfig; }
+
+  public boolean getUrlEncodeAppContext() { return this.urlEncodeAppContext; }
+
+  public void setUrlEncodeAppContext(boolean urlEncodeAppContext) { this.urlEncodeAppContext = urlEncodeAppContext; }
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -235,10 +235,13 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     String filepath = "../../getfile/" + criteria.getQueryString();
 
     String appContext = "template=" + questionnaireUri + "&request=" + reqResourceId + "&filepath=";
-    try {
-      appContext = URLEncoder.encode(appContext, "UTF-8").toString();
-    } catch (UnsupportedEncodingException e) {
-      e.printStackTrace();
+    if (myConfig.getUrlEncodeAppContext()) {
+      try {
+        logger.info("CdsService::smartLinkBuilder: URL encoding appcontext");
+        appContext = URLEncoder.encode(appContext, "UTF-8").toString();
+      } catch (UnsupportedEncodingException e) {
+        e.printStackTrace();
+      }
     }
 
     if (myConfig.getIncludeFilepathInAppContext()) {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -39,6 +39,8 @@ includeFilepathInAppContext: true
 
 appendParamsToSmartLaunchUrl: false
 
+# The appconext may need to be encoded depending on which EHR the server is running with
+urlEncodeAppContext: false
 
 cdsConnect:
   url: https://cdsconnect.ahrqstg.org


### PR DESCRIPTION
The test-ehr does not work with a url encoded app context. This change puts the encoding on a config switch until a workaround for the test-ehr can be found.