### PR TITLE
[410] Display if Prior Auth or Documentation Requirements only is required

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -144,14 +144,16 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
       CqlResultsForCard results = executeCqlAndGetRelevantResults(lookupResult.getContext());
       if (results.ruleApplies()){
         foundApplicableRule = true;
-        if (results.getQuestionnaireUri() != null && !results.getQuestionnaireUri().isEmpty()){
+        if ((results.getDocumentationRequired() || results.getPriorAuthRequired()) &&
+            (results.getQuestionnaireUri() != null && !results.getQuestionnaireUri().isEmpty())) {
           Link smartAppLink = smartLinkBuilder(
               request.getContext().getPatientId(),
               request.getFhirServer(),
               applicationBaseUrl,
               results.getQuestionnaireUri(),
               results.getRequestId(),
-              lookupResult.getCriteria());
+              lookupResult.getCriteria(),
+              results.getPriorAuthRequired());
           response.addCard(CardBuilder.transform(results, smartAppLink));
         } else{
           logger.warn("Unspecified Questionnaire URI; summary card sent to client");
@@ -178,9 +180,12 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     if (!results.ruleApplies()) {
       return results;
     }
+
     results.setSummary(evaluateStatement("RESULT_Summary",context).toString())
         .setDetails(evaluateStatement("RESULT_Details",context).toString())
-        .setInfoLink(evaluateStatement("RESULT_InfoLink",context).toString());
+        .setInfoLink(evaluateStatement("RESULT_InfoLink",context).toString())
+        .setPriorAuthRequired((Boolean) evaluateStatement("PRIORAUTH_REQUIRED", context))
+        .setDocumentationRequired((Boolean) evaluateStatement("DOCUMENTATION_REQUIRED", context));
 
     if (evaluateStatement("RESULT_QuestionnaireUri",context) != null) {
       results
@@ -202,7 +207,7 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
   }
 
   private Link smartLinkBuilder(String patientId, String fhirBase, URL applicationBaseUrl, String questionnaireUri,
-                                String reqResourceId, CoverageRequirementRuleCriteria criteria) {
+                                String reqResourceId, CoverageRequirementRuleCriteria criteria, boolean priorAuthRequired) {
     URI configLaunchUri = myConfig.getLaunchUrl();
     String launchUrl;
     if (myConfig.getLaunchUrl().isAbsolute()) {
@@ -229,12 +234,15 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     // PARAMS:
     // template is the uri of the questionnaire
     // request is the ID of the device request or medrec (not the full URI like the IG says, since it should be taken from fhirBase
-    HashMap<String,String> appContextMap = new HashMap<>();
-    appContextMap.put("template", questionnaireUri);
-    appContextMap.put("request", reqResourceId);
+    //HashMap<String,String> appContextMap = new HashMap<>();
+    //appContextMap.put("template", questionnaireUri);
+    //appContextMap.put("request", reqResourceId);
     String filepath = "../../getfile/" + criteria.getQueryString();
 
-    String appContext = "template=" + questionnaireUri + "&request=" + reqResourceId + "&filepath=";
+    String appContext = "template=" + questionnaireUri + "&request=" + reqResourceId;
+    
+    appContext = appContext + "&priorauth=" + (priorAuthRequired?"true":"false");
+    appContext = appContext + "&filepath=";
     if (myConfig.getUrlEncodeAppContext()) {
       try {
         logger.info("CdsService::smartLinkBuilder: URL encoding appcontext");

--- a/server/src/main/java/org/hl7/davinci/endpoint/components/CardBuilder.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/components/CardBuilder.java
@@ -23,6 +23,8 @@ public class CardBuilder {
     private String infoLink;
     private String questionnaireUri;
     private String requestId;
+    private Boolean priorAuthRequired;
+    private Boolean documentationRequired;
 
     public Boolean ruleApplies() {
       return ruleApplies;
@@ -79,6 +81,24 @@ public class CardBuilder {
 
     public CqlResultsForCard setRequestId(String requestId) {
       this.requestId = requestId;
+      return this;
+    }
+
+    public boolean getPriorAuthRequired() {
+      return priorAuthRequired;
+    }
+
+    public CqlResultsForCard setPriorAuthRequired(boolean priorAuthRequired) {
+      this.priorAuthRequired = priorAuthRequired;
+      return this;
+    }
+
+    public boolean getDocumentationRequired() {
+      return documentationRequired;
+    }
+
+    public CqlResultsForCard setDocumentationRequired(boolean documentationRequired) {
+      this.documentationRequired = documentationRequired;
       return this;
     }
 

--- a/server/src/main/jib/rules/cms/cpt/82947/82947.cql
+++ b/server/src/main/jib/rules/cms/cpt/82947/82947.cql
@@ -12,6 +12,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 18 and "Age" <= 60
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Authorization required.'
 

--- a/server/src/main/jib/rules/cms/cpt/94649/94649.cql
+++ b/server/src/main/jib/rules/cms/cpt/94649/94649.cql
@@ -12,6 +12,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 0 and "Age" <= 90
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Authorization required.'
 

--- a/server/src/main/jib/rules/cms/cpt/94660/94660.cql
+++ b/server/src/main/jib/rules/cms/cpt/94660/94660.cql
@@ -12,6 +12,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 18 and "Age" <= 80
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Authorization required.'
 

--- a/server/src/main/jib/rules/cms/cpt/95259/95259-r4.cql
+++ b/server/src/main/jib/rules/cms/cpt/95259/95259-r4.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 10 and "Age" <= 55
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Authorization required.'
 

--- a/server/src/main/jib/rules/cms/cpt/95259/95259.cql
+++ b/server/src/main/jib/rules/cms/cpt/95259/95259.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 10 and "Age" <= 55
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Authorization required.'
 

--- a/server/src/main/jib/rules/cms/cpt/97542/97542.cql
+++ b/server/src/main/jib/rules/cms/cpt/97542/97542.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 18 and "Age" <= 90
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No authorization required.'
 

--- a/server/src/main/jib/rules/cms/hcpcs/A0426/A0426-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/A0426/A0426-r4.cql
@@ -8,6 +8,12 @@ parameter service_request ServiceRequest
 define RULE_APPLIES:
   true
 
+define PRIORAUTH_REQUIRED:
+    true
+
+define DOCUMENTATION_REQUIRED:
+    true
+
 define RESULT_Summary:
   'Prior Authorization required.'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0110/E0110.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0110/E0110.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 21 and "Age" <= 50
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Auth required.'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0130/E0130.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0130/E0130.cql
@@ -14,6 +14,12 @@ define "Gender":
 define RULE_APPLIES:
   "Age" >= 60 and "Age" <= 90 and "Gender" = 'male'
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Auth required.'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0250/E0250-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0250/E0250-r4.cql
@@ -14,6 +14,12 @@ define "Gender":
 define RULE_APPLIES:
   true
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define "Auth_Needed":
   "Gender" = 'male'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0250/E0250.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0250/E0250.cql
@@ -14,6 +14,12 @@ define "Gender":
 define RULE_APPLIES:
   true
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define "Auth_Needed":
   "Gender" = 'male'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0424/E0424-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0424/E0424-r4.cql
@@ -6,10 +6,16 @@ parameter Patient Patient
 parameter device_request DeviceRequest
 
 define "Age":
-    AgeInYears()
+  AgeInYears()
 
 define RULE_APPLIES:
-    "Age" > 0
+  "Age" > 0
+
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
 
 define RESULT_Summary:
   'No auth needed'

--- a/server/src/main/jib/rules/cms/hcpcs/E0424/E0424.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0424/E0424.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0424_2/E0424_2.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0424_2/E0424_2.cql
@@ -22,6 +22,12 @@ define RULE_APPLIES:
   and "PatientHomeState" = 'MA'
   and "Blah" = 2
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define "Auth_Needed":
   "Age" > 57
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0431/E0431-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0431/E0431-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0431/E0431.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0431/E0431.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0433/E0433-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0433/E0433-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0433/E0433.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0433/E0433.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0434/E0434-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0434/E0434-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0434/E0434.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0434/E0434.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0439/E0439-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0439/E0439-r4.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0439/E0439.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0439/E0439.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0441/E0441-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0441/E0441-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0441/E0441.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0441/E0441.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0442/E0442-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0442/E0442-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0442/E0442.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0442/E0442.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0443/E0443-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0443/E0443-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0443/E0443.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0443/E0443.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0444/E0444-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0444/E0444-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0444/E0444.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0444/E0444.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0470/E0470-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0470/E0470-r4.cql
@@ -8,6 +8,12 @@ parameter device_request DeviceRequest
 define RULE_APPLIES:
     true
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Documentation Required.'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0470/E0470.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0470/E0470.cql
@@ -8,6 +8,12 @@ parameter device_request DeviceRequest
 define RULE_APPLIES:
   true
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Documentation Required.'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0601/E0601-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0601/E0601-r4.cql
@@ -8,6 +8,12 @@ parameter device_request DeviceRequest
 define RULE_APPLIES:
   true
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Documentation Required.'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E0601/E0601.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0601/E0601.cql
@@ -8,6 +8,12 @@ parameter device_request DeviceRequest
 define RULE_APPLIES:
   true
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Documentation Required.'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E1390/E1390-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1390/E1390-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E1390/E1390.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1390/E1390.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E1391/E1391-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1391/E1391-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E1391/E1391.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1391/E1391.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E1392/E1392-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1392/E1392-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/E1392/E1392.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1392/E1392.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/K0738/K0738-r4.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/K0738/K0738-r4.cql
@@ -17,6 +17,12 @@ define "PatientHomeState":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/hcpcs/K0738/K0738.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/K0738/K0738.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" > 0
 
+define PRIORAUTH_REQUIRED:
+  true
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No auth needed'
 

--- a/server/src/main/jib/rules/cms/rxnorm/209431/209431.cql
+++ b/server/src/main/jib/rules/cms/rxnorm/209431/209431.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 10 and "Age" <= 70
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'No authorization required.'
 

--- a/server/src/main/jib/rules/cms/rxnorm/860195/860195-r4.cql
+++ b/server/src/main/jib/rules/cms/rxnorm/860195/860195-r4.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 30 and "Age" <= 80
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Authorization is required.'
 

--- a/server/src/main/jib/rules/cms/rxnorm/860195/860195.cql
+++ b/server/src/main/jib/rules/cms/rxnorm/860195/860195.cql
@@ -11,6 +11,12 @@ define "Age":
 define RULE_APPLIES:
   "Age" >= 30 and "Age" <= 80
 
+define PRIORAUTH_REQUIRED:
+  false
+
+define DOCUMENTATION_REQUIRED:
+  true
+
 define RESULT_Summary:
   'Authorization is required.'
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -40,7 +40,7 @@ includeFilepathInAppContext: true
 appendParamsToSmartLaunchUrl: false
 
 # The appconext may need to be encoded depending on which EHR the server is running with
-urlEncodeAppContext: false
+urlEncodeAppContext: true
 
 cdsConnect:
   url: https://cdsconnect.ahrqstg.org


### PR DESCRIPTION
Update rules to include flag for prior auth and documentation. Pass the prior auth flag to DTR and suppress smart app link if neither are required.