### PR TITLE
714 - ValueSets in Questionnaires

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/controllers/DataController.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/controllers/DataController.java
@@ -117,15 +117,16 @@ public class DataController {
     logger.info("GET /fhir/R4/ValueSet/$expand");
 
     if (url != null) {
-      // If URL appears to be a canonical VSAC url or starts with this server's base url
-      if (url.startsWith(ValueSetCache.VSAC_CANONICAL_BASE) || url.startsWith(baseUrl)) {
+      // If URL starts with this server's base url, pull out id and search by id
+      if (url.startsWith(baseUrl)) {
         String valueSetId = url.split("ValueSet/")[1];
         FileResource fileResource = fileStore.getFhirResourceById("R4", "valueset", "valueset/" + valueSetId, baseUrl);
         return processFileResource(fileResource);
 
-      // If the URL is pointing to a valueset of unknown origin, return 404 not found
+      // If the URL is from elsewhere, look by URL
       } else {
-        return ResponseEntity.notFound().build();
+        FileResource fileResource = fileStore.getFhirResourceByUrl("R4", "valueset", url, baseUrl);
+        return processFileResource(fileResource);
       }
 
     // if the URL was not provided, we cannot provide an expansion. return 401 bad request

--- a/server/src/main/java/org/hl7/davinci/endpoint/database/FhirResource.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/database/FhirResource.java
@@ -11,6 +11,9 @@ public class FhirResource {
   @Column(name = "id", updatable = false, nullable = false)
   private String id;
 
+  @Column(name = "url", updatable = false, nullable = true)
+  private String url;
+
   @Id
   @Column(name = "resource_type", nullable = false)
   private String resourceType;
@@ -34,6 +37,15 @@ public class FhirResource {
 
   public FhirResource setId(String id) {
     this.id = id;
+    return this;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public FhirResource setUrl(String url) {
+    this.url = url;
     return this;
   }
 
@@ -79,10 +91,10 @@ public class FhirResource {
   }
 
   public static String getColumnsString() {
-    return "id / resourceType / fhirVersin / topic / filename / name";
+    return "id / resourceType / fhirVersion / topic / filename / name / url";
   }
 
   public String toString() {
-    return id + " / " + resourceType + " / " + fhirVersion + " / " + topic + " / " + filename + " / " + name;
+    return id + " / " + resourceType + " / " + fhirVersion + " / " + topic + " / " + filename + " / " + name + " / " + ((url != null) ? url : "null");
   }
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/database/FhirResourceCriteria.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/database/FhirResourceCriteria.java
@@ -6,6 +6,7 @@ public class FhirResourceCriteria {
   private String resourceType;
   private String name;
   private String id;
+  private String url;
 
   public String getFhirVersion() { return fhirVersion; }
 
@@ -32,6 +33,13 @@ public class FhirResourceCriteria {
 
   public FhirResourceCriteria setId(String id) {
     this.id = id;
+    return this;
+  }
+
+  public String getUrl() { return url; }
+
+  public FhirResourceCriteria setUrl(String url) {
+    this.url = url;
     return this;
   }
 

--- a/server/src/main/java/org/hl7/davinci/endpoint/database/FhirResourceRepository.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/database/FhirResourceRepository.java
@@ -31,4 +31,13 @@ public interface FhirResourceRepository extends CrudRepository<FhirResource, Lon
   List<FhirResource> findByName(
       @Param("criteria") FhirResourceCriteria criteria
   );
+
+  @Query(
+      "SELECT r FROM FhirResource r WHERE "
+          + "r.fhirVersion = :#{#criteria.fhirVersion} "
+          + "and r.resourceType = :#{#criteria.resourceType} "
+          + "and r.url = :#{#criteria.url}")
+  List<FhirResource> findByUrl(
+      @Param("criteria") FhirResourceCriteria criteria
+  );
 }

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/FhirResourceProcessor.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/FhirResourceProcessor.java
@@ -1,0 +1,79 @@
+package org.hl7.davinci.endpoint.files;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ByteArrayResource;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+
+/**
+ * Abstract interface for making changes to a FHIR resource. This takes care of the parsing
+ * of the resource and encoding back out to a deliverable buffer. The implementing classes
+ * just need to implement processResource and work with the FHIR models solely.
+ * 
+ * @param <T> Any FHIR R4 Resource model.
+ */
+public abstract class FhirResourceProcessor<T extends Resource> {
+
+  static final Logger logger = LoggerFactory.getLogger(FhirResourceProcessor.class);
+
+  /**
+   * Implemented by the concrete processor. Makes any changes to the FHIR Resource and returns the
+   * modified Resource
+   * 
+   * @param inputResource The Resource to modify.
+   * @param fileStore The FileStore that may be used if other resources are needed.
+   * @param baseUrl The base url of the server, usually obtained by the current request.
+   * @return The new or modified FHIR Resource.
+   */
+  protected abstract T processResource(T inputResource, FileStore fileStore, String baseUrl);
+
+  private FhirContext ctx;
+  private IParser parser;
+
+  public FhirResourceProcessor() {
+    this.ctx = new org.hl7.davinci.r4.FhirComponents().getFhirContext();
+    this.parser = ctx.newJsonParser().setPrettyPrint(true);
+  }
+
+  /**
+   * Called by CommonFileStore/other users. This is the main entry point for the use of the processor.
+   * Will call the abstract `processResource` to actually do the work.
+   * 
+   * @param inputFileResource The FileResource that will be parsed, then modified.
+   * @param fileStore The file store to be used if any other resources need to be pulled for modifications.
+   * @param baseUrl The base url of the server, usually obtained by the current request.
+   * @return The new FileResource after modification.
+   */
+  public FileResource processResource(FileResource inputFileResource, FileStore fileStore, String baseUrl) {
+    T inputResource = (T) this.parseFhirFileResource(inputFileResource);
+    T outputResource = this.processResource(inputResource, fileStore, baseUrl);
+
+    byte[] resourceData = parser.encodeResourceToString(outputResource).getBytes(Charset.defaultCharset());
+    FileResource outputFileResource = new FileResource();
+    outputFileResource.setResource(new ByteArrayResource(resourceData));
+    outputFileResource.setFilename(inputFileResource.getFilename());
+    return outputFileResource;
+  }
+
+  /**
+   * Parses a FHIR resource from a FileResource.
+   * 
+   * @param fileResource The FileResource to parse.
+   * @return The parsed FHIR R4 model.
+   */
+  protected Resource parseFhirFileResource(FileResource fileResource) {
+    try {
+      return (Resource) parser.parseResource(fileResource.getResource().getInputStream());
+    } catch(IOException ioe) {
+      logger.error("Issue parsing FHIR file resource for preprocessing.", ioe);
+      return null;
+    }
+  }
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/FileStore.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/FileStore.java
@@ -18,6 +18,7 @@ public interface FileStore {
 
   FileResource getFhirResourceByTopic(String fhirVersion, String resourceType, String name, String baseUrl);
   FileResource getFhirResourceById(String fhirVersion, String resourceType, String id, String baseUrl);
+  FileResource getFhirResourceByUrl(String fhirVersion, String resourceType, String url, String baseUrl);
 
   // from RuleFinder
   List<RuleMapping> findRules(CoverageRequirementRuleCriteria criteria);

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/QuestionnaireValueSetProcessor.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/QuestionnaireValueSetProcessor.java
@@ -1,0 +1,110 @@
+package org.hl7.davinci.endpoint.files;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemInitialComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Processes FHIR R4 Questionnaires to have referenced valuesets embedded.
+ */
+public class QuestionnaireValueSetProcessor extends FhirResourceProcessor<Questionnaire> {
+
+  static final Logger logger = LoggerFactory.getLogger(QuestionnaireValueSetProcessor.class);
+
+  /**
+   * Processes the Questionnaire to have referenced ValueSets included in the contains field.
+   */
+	@Override
+	protected Questionnaire processResource(Questionnaire inputResource, FileStore fileStore, String baseUrl) {
+
+    // Initialize map of created urls to valuesets to embed
+    Map<String, ValueSet> valueSetMap = new HashMap<String, ValueSet>();
+
+    // Iterate through items recursively and replace answerValueSet appropiately
+    findAndReplaceValueSetReferences(inputResource.getItem(), valueSetMap, fileStore, baseUrl);
+
+    // Add all loaded valuesets to the contains field
+    for (ValueSet valueSet : valueSetMap.values()) {
+      inputResource.addContained(valueSet);
+      logger.info("Embedding " + valueSet.getId() + " in contained.");
+    }
+
+		return inputResource;
+  }
+
+  /**
+   * Recursively visits every questionnaire item and replaces every `answerValueSet` that isn't a local
+   * hash (#) reference into a local reference. This fills the valueSetMap with the loaded valuesets.
+   * 
+   * @param itemComponents The item components to visit.
+   * @param valueSetMap A mapping of ValueSet urls to loaded valuesets that should be filled as references are found.
+   * @param fileStore The file store that is used to load valuesets from.
+   * @param baseUrl The base url of the server from the request. Used to identify local valuesets.
+   */
+  private void findAndReplaceValueSetReferences(List<QuestionnaireItemComponent> itemComponents, Map<String, ValueSet> valueSetMap, FileStore fileStore, String baseUrl) {
+    for (QuestionnaireItemComponent itemComponent : itemComponents) {
+      // If there is an answerValueSet field we need to do some work on this item
+      if (itemComponent.hasAnswerValueSet()) {
+        
+        if (!itemComponent.getAnswerValueSet().startsWith("#")) {
+          logger.info("answerValueSet found with url - " + itemComponent.getAnswerValueSet());
+          String valueSetId = findAndLoadValueSet(itemComponent.getAnswerValueSet(), valueSetMap, fileStore, baseUrl);
+          itemComponent.setAnswerValueSet("#" + valueSetId);
+          logger.info("answerValueSet replaced with  - " + itemComponent.getAnswerValueSet());
+        }
+
+        // Add initial reference to any item with an answerValueSet due to HAPI encoder error.
+        // This is needed to make sure the referenced ValueSets in contains are included.
+        QuestionnaireItemInitialComponent initial = new QuestionnaireItemInitialComponent(
+          new Reference(itemComponent.getAnswerValueSet()));
+        itemComponent.addInitial(initial);
+      }
+
+      // Recurse down into child items.
+      if (itemComponent.hasItem()) {
+        findAndReplaceValueSetReferences(itemComponent.getItem(), valueSetMap, fileStore, baseUrl);
+      }
+    }
+  }
+
+  /**
+   * Finds a value set, loads it and modifies its id and url fields to work in the contains field.
+   * 
+   * @param url The canonical url of the valueset to look for.
+   * @param valueSetMap The map of valuesets that have been loaded already.
+   * @return The local ID to use for the valueset.
+   */
+  private String findAndLoadValueSet(String url, Map<String, ValueSet> valueSetMap, FileStore fileStore, String baseUrl) {
+    if (valueSetMap.containsKey(url)) {
+      return valueSetMap.get(url).getId();
+    }
+
+    FileResource valueSetFileResource;
+    ValueSet valueSet;
+    // If URL starts with this server's base url, pull out id and search by id
+    if (url.startsWith(baseUrl)) {
+      String valueSetId = url.split("ValueSet/")[1];
+      valueSetFileResource = fileStore.getFhirResourceById("R4", "valueset", "valueset/" + valueSetId, baseUrl);
+    } else {
+      valueSetFileResource = fileStore.getFhirResourceByUrl("R4", "valueset", url, baseUrl);
+    }
+
+    // parse value set and modify ID and #URL to match.
+    valueSet = (ValueSet) this.parseFhirFileResource(valueSetFileResource);
+    String valueSetId = valueSet.getIdElement().getIdPart();
+    valueSet.setId(valueSetId);
+    valueSet.setUrl("#" + valueSetId);
+
+    // add it to the value set map so it can be reused
+    valueSetMap.put(url, valueSet);
+    return valueSetId;
+  }
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/cdsconnect/CdsConnectFileStore.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/cdsconnect/CdsConnectFileStore.java
@@ -70,6 +70,16 @@ public class CdsConnectFileStore implements FileStore {
     return fileResource;
   }
 
+  public FileResource getFhirResourceByUrl(String fhirVersion, String resourceType, String url, String baseUrl) {
+    logger.info("CdsConnectFileStore::getFhirResourceById(): " + fhirVersion + "/" + resourceType + "/" + url);
+    String filename = "";
+    FileResource fileResource = new FileResource();
+    fileResource.setFilename(filename);
+    byte[] fileData = null;
+    fileResource.setResource(new ByteArrayResource(fileData));
+    return fileResource;
+  }
+
   public List<RuleMapping> findRules(CoverageRequirementRuleCriteria criteria) {
     logger.info("CdsConnectFileStore::findRules(): " + criteria.toString());
     return new ArrayList<>();

--- a/server/src/main/java/org/hl7/davinci/endpoint/vsac/ValueSetCache.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/vsac/ValueSetCache.java
@@ -262,7 +262,8 @@ public class ValueSetCache {
           .setResourceType("valueset")
           .setTopic(VSAC_TOPIC)
           .setFilename(valueSetPath.getName())
-          .setName(valueSet.getName());
+          .setName(valueSet.getName())
+          .setUrl(valueSet.getUrl());
       fhirResources.save(fhirResource);
       logger.info("Added ValueSet (" + valueSet.getId() + ") to FhirResourceRepository");
     } else {


### PR DESCRIPTION
Stores the url fields of ValueSets when loaded and adds a way to search by the urls. This adds support for valuesets from other sources with canonical urls to be used as long as they can be pulled in to our CDS-Library repo.

Embeds referenced valuesets in questionnaires and provides an abstract class for doing generic modifications on FHIR resources.

An example of using this work with the HL7 FHIR administrative-gender valueset in the HOT questionnaire can be seen by using the `hot-valuesets-questionnaire` branch of CDS-Library.