### PR TITLE
751- Sub-questionnaire refactor

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/files/FileStore.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/FileStore.java
@@ -23,6 +23,7 @@ public interface FileStore {
 
   FileResource getFhirResourceByTopic(String fhirVersion, String resourceType, String name, String baseUrl);
   FileResource getFhirResourceById(String fhirVersion, String resourceType, String id, String baseUrl);
+  FileResource getFhirResourceById(String fhirVersion, String resourceType, String id, String baseUrl, boolean isRoot);
   FileResource getFhirResourceByUrl(String fhirVersion, String resourceType, String url, String baseUrl);
 
   // from RuleFinder

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/SubQuestionnaireProcessor.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/SubQuestionnaireProcessor.java
@@ -15,16 +15,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.hl7.fhir.r4.model.Resource;
 
+/**
+ * Processes FHIR R4 questionnaire to assemble sub-questionnaires into a complete questionnaire.
+ */
 public class SubQuestionnaireProcessor extends FhirResourceProcessor<Questionnaire> {
 
   static final Logger logger = LoggerFactory.getLogger(SubQuestionnaireProcessor.class);
 
+  /**
+   * Processes a Questionnaire to replace all sub-questionnaire references with the items.
+   */
 	@Override
 	protected Questionnaire processResource(Questionnaire inputResource, FileStore fileStore, String baseUrl) {
 		return this.assembleQuestionnaire(inputResource, fileStore, baseUrl);
 	}
   
-
+  /**
+   * Assemble a questionnaire to have all sub-questionnaires pulled into this questionnaire.
+   * 
+   * @param q The Questionnaire to assemble.
+   * @param fileStore The FileStore to be used for fetching sub-questionnaires.
+   * @param baseUrl The base url from the server.
+   * @return The assembled questionnaire.
+   */
   protected Questionnaire assembleQuestionnaire(Questionnaire q, FileStore fileStore, String baseUrl) {
     logger.info("SubQuestionnaireProcessor::assembleQuestionnaire(): " + q.getId());
 
@@ -38,7 +51,7 @@ public class SubQuestionnaireProcessor extends FhirResourceProcessor<Questionnai
 
     int containedSize = containedList.size();
 
-    parseItemList(q.getItem(), fileStore, baseUrl, containedList, extensionList);
+    processItemList(q.getItem(), fileStore, baseUrl, containedList, extensionList);
     
     if (containedSize != containedList.size())
       q.setContained(new ArrayList<org.hl7.fhir.r4.model.Resource>(containedList.values()));
@@ -46,14 +59,23 @@ public class SubQuestionnaireProcessor extends FhirResourceProcessor<Questionnai
     return q;
   }
 
-  private void parseItemList(List<QuestionnaireItemComponent> itemList, FileStore fileStore, String baseUrl,
+  /**
+   * Iterate over and modify a list of questionnaire items. This will up date the list of items as sub-questionnaire references are found.
+   * 
+   * @param itemList The Item list to iterate over.
+   * @param fileStore The FileStore to be used for fetching sub-questionnaires.
+   * @param baseUrl The base url from the server.
+   * @param containedList List of contained resources to put in the assembled Questionnaire. This will be filled while iterating.
+   * @param extensionList List of extensions to put in the assembled Questionnaire. This will be filled while iterating.
+   */
+  private void processItemList(List<QuestionnaireItemComponent> itemList, FileStore fileStore, String baseUrl,
     Hashtable<String, org.hl7.fhir.r4.model.Resource> containedList, List<Extension> extensionList) {
     if (itemList == null || itemList.size() == 0)
       return;
 
     for (int i = 0; i < itemList.size();) {
       List<QuestionnaireItemComponent> returnedItemList = 
-        parseItem(itemList.get(i), fileStore, baseUrl, containedList, extensionList);
+        processItem(itemList.get(i), fileStore, baseUrl, containedList, extensionList);
       
       if (returnedItemList.size() == 0) {
         continue;
@@ -71,7 +93,18 @@ public class SubQuestionnaireProcessor extends FhirResourceProcessor<Questionnai
     }
   }
 
-  private List<QuestionnaireItemComponent> parseItem(QuestionnaireItemComponent item, FileStore fileStore, String baseUrl,
+  /**
+   * Determines if this item is a sub-questionnaire reference and returns the items to replace it with. Returns the same list
+   * otherwise. Also recursively continues scanning if this is just a grouping item.
+   * 
+   * @param item The item to check for sub-questionnaire referece.
+   * @param fileStore The FileStore to be used for fetching sub-questionnaires.
+   * @param baseUrl The base url from the server.
+   * @param containedList List of contained resources to put in the assembled Questionnaire. This will be filled while iterating.
+   * @param extensionList List of extensions to put in the assembled Questionnaire. This will be filled while iterating.
+   * @return New list of items to replace this item with.
+   */
+  private List<QuestionnaireItemComponent> processItem(QuestionnaireItemComponent item, FileStore fileStore, String baseUrl,
   Hashtable<String, org.hl7.fhir.r4.model.Resource> containedList, List<Extension> extensionList) {
     // find if item has an extension is sub-questionnaire
     Extension e = item.getExtensionByUrl("http://hl7.org/fhir/StructureDefinition/sub-questionnaire");
@@ -106,7 +139,7 @@ public class SubQuestionnaireProcessor extends FhirResourceProcessor<Questionnai
     }
     
     // parse sub-items
-    this.parseItemList(item.getItem(), fileStore, baseUrl, containedList, extensionList);
+    this.processItemList(item.getItem(), fileStore, baseUrl, containedList, extensionList);
 
     return Arrays.asList(item);
   }

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/SubQuestionnaireProcessor.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/SubQuestionnaireProcessor.java
@@ -1,0 +1,113 @@
+package org.hl7.davinci.endpoint.files;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.hl7.fhir.r4.model.Resource;
+
+public class SubQuestionnaireProcessor extends FhirResourceProcessor<Questionnaire> {
+
+  static final Logger logger = LoggerFactory.getLogger(SubQuestionnaireProcessor.class);
+
+	@Override
+	protected Questionnaire processResource(Questionnaire inputResource, FileStore fileStore, String baseUrl) {
+		return this.assembleQuestionnaire(inputResource, fileStore, baseUrl);
+	}
+  
+
+  protected Questionnaire assembleQuestionnaire(Questionnaire q, FileStore fileStore, String baseUrl) {
+    logger.info("SubQuestionnaireProcessor::assembleQuestionnaire(): " + q.getId());
+
+
+    List<Extension> extensionList = q.getExtension();
+    Hashtable<String, org.hl7.fhir.r4.model.Resource> containedList = new Hashtable<String, org.hl7.fhir.r4.model.Resource>();
+
+    for (org.hl7.fhir.r4.model.Resource r : q.getContained()) {
+      containedList.put(r.getId(), r);
+    }
+
+    int containedSize = containedList.size();
+
+    parseItemList(q.getItem(), fileStore, baseUrl, containedList, extensionList);
+    
+    if (containedSize != containedList.size())
+      q.setContained(new ArrayList<org.hl7.fhir.r4.model.Resource>(containedList.values()));
+
+    return q;
+  }
+
+  private void parseItemList(List<QuestionnaireItemComponent> itemList, FileStore fileStore, String baseUrl,
+    Hashtable<String, org.hl7.fhir.r4.model.Resource> containedList, List<Extension> extensionList) {
+    if (itemList == null || itemList.size() == 0)
+      return;
+
+    for (int i = 0; i < itemList.size();) {
+      List<QuestionnaireItemComponent> returnedItemList = 
+        parseItem(itemList.get(i), fileStore, baseUrl, containedList, extensionList);
+      
+      if (returnedItemList.size() == 0) {
+        continue;
+      }
+
+      if (returnedItemList.size() == 1) {
+        itemList.set(i, returnedItemList.get(0));
+      }
+      else {
+        itemList.remove(i);
+        itemList.addAll(i, returnedItemList);
+      }
+
+      i += returnedItemList.size();
+    }
+  }
+
+  private List<QuestionnaireItemComponent> parseItem(QuestionnaireItemComponent item, FileStore fileStore, String baseUrl,
+  Hashtable<String, org.hl7.fhir.r4.model.Resource> containedList, List<Extension> extensionList) {
+    // find if item has an extension is sub-questionnaire
+    Extension e = item.getExtensionByUrl("http://hl7.org/fhir/StructureDefinition/sub-questionnaire");
+
+    if (e != null) {
+      // read sub questionnaire from file store
+      CanonicalType value = e.castToCanonical(e.getValue());
+      logger.info("SubQuestionnaireProcessor::parseItem(): Looking for SubQuestionnaire " + value);
+      FileResource subFileResource = fileStore.getFhirResourceById("R4", "questionnaire", value.asStringValue(), baseUrl, false);
+      Questionnaire subQuestionnaire = (Questionnaire) this.parseFhirFileResource(subFileResource);
+
+      if (subQuestionnaire != null) {
+        // merge extensions
+        for (Extension subExtension : subQuestionnaire.getExtension()) {
+          if (extensionList.stream().noneMatch(ext -> ext.equalsDeep(subExtension))) {
+            extensionList.add(subExtension);
+          }
+        }
+
+        // merge contained resources
+        for (org.hl7.fhir.r4.model.Resource r : subQuestionnaire.getContained()) {
+          containedList.put(r.getId(), r);
+        }
+
+        return subQuestionnaire.getItem();
+
+      } else {
+        // SubQuestionnaire was not found
+        logger.warn("SubQuestionnaireProcessor::parseItem(): Could not find " + value);
+        return Arrays.asList(item);
+      }
+    }
+    
+    // parse sub-items
+    this.parseItemList(item.getItem(), fileStore, baseUrl, containedList, extensionList);
+
+    return Arrays.asList(item);
+  }
+}


### PR DESCRIPTION
Moves sub-questionnaire refactoring code out of CommonFileStore into it's own resource processor class.

Best tested with the Ventilator Order rule with `pat016`.