### PR TITLE
DMEERX-754 Library translation support

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     //Use locally compiled cql libs (engine and fhir)
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.4.6'
+    compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.4.9'
 
     compile 'org.zeroturnaround:zt-zip:1.13'
 

--- a/server/src/main/java/org/hl7/davinci/endpoint/cql/CqlExecution.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cql/CqlExecution.java
@@ -7,6 +7,7 @@ import javax.xml.bind.JAXBException;
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.FhirLibrarySourceProvider;
 import org.cqframework.cql.elm.execution.Library;
@@ -18,10 +19,13 @@ import org.opencds.cqf.cql.execution.CqlLibraryReader;
 
 public class CqlExecution {
 
-  public static String translateToElm(String cql) throws Exception {
+  public static String translateToElm(String cql, LibrarySourceProvider librarySourceProvider) throws Exception {
     ModelManager modelManager = new ModelManager();
     LibraryManager libraryManager = new LibraryManager(modelManager);
     libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
+    if (librarySourceProvider != null) {
+      libraryManager.getLibrarySourceLoader().registerProvider(librarySourceProvider);
+    }
 
     ArrayList<CqlTranslator.Options> options = new ArrayList<>();
     options.add(CqlTranslator.Options.EnableDateRangeOptimization);
@@ -42,6 +46,10 @@ public class CqlExecution {
     }
 
     return translator.toJson();
+  }
+
+  public static String translateToElm(String cql) throws Exception {
+    return translateToElm(cql, null);
   }
 
   public static Library translate(String cql, LibraryManager libraryManager, ModelManager modelManager) throws Exception {

--- a/server/src/main/java/org/hl7/davinci/endpoint/cql/LocalLibraryLoader.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cql/LocalLibraryLoader.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
+
+import org.cqframework.cql.cql2elm.CqlTranslatorOptions;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.elm.execution.Library;
@@ -64,7 +66,8 @@ public class LocalLibraryLoader implements org.opencds.cqf.cql.execution.Library
         .withSystem(libraryIdentifier.getSystem())
         .withVersion(libraryIdentifier.getVersion());
 
-    org.cqframework.cql.cql2elm.model.TranslatedLibrary translatedLibrary = libraryManager.resolveLibrary(identifier, errors);
+    CqlTranslatorOptions options = new CqlTranslatorOptions();
+    org.cqframework.cql.cql2elm.model.TranslatedLibrary translatedLibrary = libraryManager.resolveLibrary(identifier, options, errors);
 
     String xml;
     try {

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/CDSLibrarySourceProvider.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/CDSLibrarySourceProvider.java
@@ -1,0 +1,43 @@
+package org.hl7.davinci.endpoint.files;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.cqframework.cql.cql2elm.LibrarySourceProvider;
+import org.hl7.elm.r1.VersionedIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CDSLibrarySourceProvider implements LibrarySourceProvider {
+
+  static final Logger logger = LoggerFactory.getLogger(CDSLibrarySourceProvider.class);
+
+  public static String LIBRARY_TOPIC = "Shared";
+
+  private FileStore fileStore;
+
+  public CDSLibrarySourceProvider(FileStore fileStore) {
+    this.fileStore = fileStore;
+  }
+
+	@Override
+	public InputStream getLibrarySource(VersionedIdentifier libraryIdentifier) {
+    String filename = libraryIdentifier.getId() + "-" + libraryIdentifier.getVersion() + ".cql";
+
+    FileResource file = fileStore.getFile(LIBRARY_TOPIC, filename, "r4", false);
+
+    if (file != null) {
+      try {
+        logger.info("Found " + filename + " CQL Library.");
+        return file.getResource().getInputStream();
+      } catch (IOException ioe) {
+        logger.error("Error loading " + filename + " CQL Library.");
+        return null;
+      }
+    } else {
+      logger.warn("Could not find " + filename + " CQL Library.");
+      return null;
+    }
+	}
+  
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/cdsconnect/CdsConnectFileStore.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/cdsconnect/CdsConnectFileStore.java
@@ -295,7 +295,7 @@ public class CdsConnectFileStore extends CommonFileStore {
         String cql = new String(fileData);
         byte[] elmFileData = null;
         try {
-          String elm = CqlExecution.translateToElm(cql);
+          String elm = CqlExecution.translateToElm(cql, new CDSLibrarySourceProvider(this));
           elmFileData = elm.getBytes();
         } catch (Exception e) {
           logger.warn("CdsConnectFileStore::getFile() Error: could not convert CQL: " + e.getMessage());

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/github/GitHubFileStore.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/github/GitHubFileStore.java
@@ -304,7 +304,7 @@ public class GitHubFileStore extends CommonFileStore {
         String cql = IOUtils.toString(inputStream, Charset.defaultCharset());
         byte[] fileData = null;
         try {
-          String elm = CqlExecution.translateToElm(cql);
+          String elm = CqlExecution.translateToElm(cql, new CDSLibrarySourceProvider(this));
           fileData = elm.getBytes();
         } catch (Exception e) {
           logger.warn("GitHubFileStore::getFile() Error: could not convert CQL: " + e.getMessage());

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/local/LocalFileStore.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/local/LocalFileStore.java
@@ -1,6 +1,8 @@
 package org.hl7.davinci.endpoint.files.local;
 
 import org.apache.commons.io.FilenameUtils;
+import org.cqframework.cql.cql2elm.LibrarySourceProvider;
+import org.cqframework.cql.elm.execution.VersionedIdentifier;
 import org.hl7.davinci.endpoint.cql.CqlExecution;
 import org.hl7.davinci.endpoint.cql.CqlRule;
 import org.hl7.davinci.endpoint.database.*;
@@ -107,7 +109,7 @@ public class LocalFileStore extends CommonFileStore {
         logger.info("LocalFileStore::getFile() converting CQL to JSON ELM");
         String cql = new String(fileData);
         try {
-          String elm = CqlExecution.translateToElm(cql);
+          String elm = CqlExecution.translateToElm(cql, new CDSLibrarySourceProvider(this));
           fileData = elm.getBytes();
         } catch (Exception e) {
           logger.warn("LocalFileStore::getFile() Error: could not convert CQL: " + e.getMessage());
@@ -147,6 +149,16 @@ public class LocalFileStore extends CommonFileStore {
     }
 
     return fileString;
+  }
+
+  private class CqlLibrarySourceProvider implements LibrarySourceProvider {
+
+    @Override
+    public InputStream getLibrarySource(org.hl7.elm.r1.VersionedIdentifier libraryIdentifier) {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
   }
 }
 

--- a/server/src/main/jib/rules/cms/cpt/95259/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/cpt/95259/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/A0426/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/A0426/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0250/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0250/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0424/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0424/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0431/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0431/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0433/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0433/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0434/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0434/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0439/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0439/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0441/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0441/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0442/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0442/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0443/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0443/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0444/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0444/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0465/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0465/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0470/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0470/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E0601/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E0601/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E1390/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1390/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E1391/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1391/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/E1392/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/E1392/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/hcpcs/K0738/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/hcpcs/K0738/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/rules/cms/rxnorm/860195/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/rules/cms/rxnorm/860195/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/main/jib/smartAppFhirArtifacts/FHIRHelpers-4.0.0.cql
+++ b/server/src/main/jib/smartAppFhirArtifacts/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value

--- a/server/src/test/resources/CDS-Library/Shared/R4/files/FHIRHelpers-4.0.0.cql
+++ b/server/src/test/resources/CDS-Library/Shared/R4/files/FHIRHelpers-4.0.0.cql
@@ -125,7 +125,7 @@ define function ToString(value FHIR.ConditionalDeleteStatus): value.value
 define function ToString(value FHIR.url): value.value
 define function ToString(value FHIR.uri): value.value
 define function ToString(value FHIR.Use): value.value
-define function ToString(value FHIR.medicationRequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestStatus): value.value
 define function ToString(value FHIR.IdentityAssuranceLevel): value.value
 define function ToString(value FHIR.DeviceMetricColor): value.value
 define function ToTime(value FHIR.time): value.value
@@ -151,7 +151,7 @@ define function ToString(value FHIR.GuidanceResponseStatus): value.value
 define function ToString(value FHIR.RelatedArtifactType): value.value
 define function ToString(value FHIR.oid): value.value
 define function ToString(value FHIR.CompartmentType): value.value
-define function ToString(value FHIR.medicationrequestStatus): value.value
+define function ToString(value FHIR.MedicationRequestIntent): value.value
 define function ToString(value FHIR.InvoicePriceComponentType): value.value
 define function ToString(value FHIR.DeviceMetricCalibrationState): value.value
 define function ToString(value FHIR.GroupType): value.value


### PR DESCRIPTION
Updates cql-to-elm to 1.4.9
Supports translating CQL libraries that reference other libraries.

For testing, HOT Order with William Oster. With CDS_Library branch `Shared_CQL_Library` and DTR `library-support-and-valueset-errors`.
