### PR TITLE
Fix case sensitivity issue on FHIR version in CDS Library Source Provider.

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/files/CDSLibrarySourceProvider.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/CDSLibrarySourceProvider.java
@@ -24,7 +24,7 @@ public class CDSLibrarySourceProvider implements LibrarySourceProvider {
 	public InputStream getLibrarySource(VersionedIdentifier libraryIdentifier) {
     String filename = libraryIdentifier.getId() + "-" + libraryIdentifier.getVersion() + ".cql";
 
-    FileResource file = fileStore.getFile(LIBRARY_TOPIC, filename, "r4", false);
+    FileResource file = fileStore.getFile(LIBRARY_TOPIC, filename, "R4", false);
 
     if (file != null) {
       try {


### PR DESCRIPTION
Without this change retrieving some Library files on Linux fails.