### PR TITLE
added debugger for docker configuration back

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Debug CRD (Local + Docker)", // gradle bootRun -Pdebug,
+            "request": "attach",
+            "hostName": "localhost",
+            "port": 8091,
+        }
+    ]
+} 


### PR DESCRIPTION
the .vscode folder from the CRD repo (https://github.com/HL7-DaVinci/CRD/pull/266/files#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945) that was used for debugging capabilities in the docker dev set up was removed. I had added that in as part of my docker dev set up, which allowed for running the entire drls + pas set up within docker containers along with the option to debug each server (add breakpoints and step through, etc.). That vscode configuration was a part of that (see: https://github.com/HL7-DaVinci/CRD/pull/264/files#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945, which is the pr merged right before yours). This pr adds that file back into the repo