### PR TITLE
Fix issues created recently with GitHub file retrieval. 

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/files/LibraryContentProcessor.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/LibraryContentProcessor.java
@@ -6,8 +6,9 @@ import org.hl7.fhir.r4.model.Base64BinaryType;
 import org.hl7.fhir.r4.model.Library;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
- 
+
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -87,8 +88,9 @@ public class LibraryContentProcessor extends FhirResourceProcessor<Library> {
     Attachment attachment = new Attachment();
     try {
       // base64 encode
-      byte[] byteData = new byte[(int) fileResource.getResource().contentLength()];
-      fileResource.getResource().getInputStream().read(byteData, 0, byteData.length);
+      InputStream inputStream = fileResource.getResource().getInputStream();
+      byte[] byteData = new byte[inputStream.available()];
+      inputStream.read(byteData);
       String encodedData = Base64.encodeBase64String(byteData);
       attachment.setContentType(mimeType);
       Base64BinaryType b64bType = new Base64BinaryType();

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/github/GitHubFileStore.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/github/GitHubFileStore.java
@@ -316,6 +316,7 @@ public class GitHubFileStore extends CommonFileStore {
 
   public FileResource getFile(String topic, String fileName, String fhirVersion, boolean convert) {
     FileResource fileResource = new FileResource();
+    fhirVersion = fhirVersion.toUpperCase();
     fileResource.setFilename(fileName);
 
     String rulePath = config.getGitHubConfig().getRulePath();


### PR DESCRIPTION
Make FHIR version all caps and make sure to read the stream only once when converting CQL to ELM.