### PR TITLE
Fix issue on docker where CQL files fail to be embedded in the Library.

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/files/LibraryContentProcessor.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/LibraryContentProcessor.java
@@ -49,7 +49,7 @@ public class LibraryContentProcessor extends FhirResourceProcessor<Library> {
 
               // content is CQL (assuming elm/json is actually CQL)
               String topic = urlParts[1];
-              String fhirVersion = urlParts[2];
+              String fhirVersion = urlParts[2].toUpperCase();
               String fileName = urlParts[3];
 
               List<Attachment> attachments = new ArrayList<>();


### PR DESCRIPTION
The fix is to get the path right with an uppercase 'R4' for the FHIR version.