### PR TITLE
App context changes

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -366,9 +366,10 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
     }
 
     // PARAMS:
-    // template is the uri of the questionnaire
-    // request is the ID of the device request or medrec (not the full URI like the
-    // IG says, since it should be taken from fhirBase
+    // questionnaire is the canonical uri of the questionnaire resource
+    // order is the request (DeviceRequest, ServiceRequest, MedicationRequest, MedicationDispense, etc)
+    // coverage is the insurance information
+    // can optionally include a "response" parameter for a QuestionnaireResponse resource to relaunch from
 
     String appContext = "questionnaire=" + questionnaireUri + "&order=" + reqResourceId + "&coverage=" + FhirRequestProcessor.getCoverageFromRequest(request).getReference();
 

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -1,40 +1,26 @@
 package org.hl7.davinci.endpoint.cdshooks.services.crd;
 
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Date;
-import javax.validation.Valid;
-
 import com.google.gson.Gson;
-
 import org.apache.commons.lang.StringUtils;
 import org.cdshooks.*;
 import org.hl7.davinci.FhirComponentsT;
 import org.hl7.davinci.PrefetchTemplateElement;
 import org.hl7.davinci.RequestIncompleteException;
 import org.hl7.davinci.endpoint.cdshooks.services.crd.r4.FhirRequestProcessor;
-import org.hl7.davinci.endpoint.config.YamlConfig;
 import org.hl7.davinci.endpoint.components.CardBuilder;
-import org.hl7.davinci.endpoint.components.PrefetchHydrator;
 import org.hl7.davinci.endpoint.components.CardBuilder.CqlResultsForCard;
+import org.hl7.davinci.endpoint.components.PrefetchHydrator;
 import org.hl7.davinci.endpoint.components.QueryBatchRequest;
+import org.hl7.davinci.endpoint.config.YamlConfig;
 import org.hl7.davinci.endpoint.database.FhirResourceRepository;
 import org.hl7.davinci.endpoint.database.RequestLog;
 import org.hl7.davinci.endpoint.database.RequestService;
 import org.hl7.davinci.endpoint.files.FileStore;
-import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleCriteria;
 import org.hl7.davinci.endpoint.rules.CoverageRequirementRuleResult;
 import org.hl7.davinci.r4.CardTypes;
 import org.hl7.davinci.r4.CoverageGuidance;
-import org.hl7.davinci.r4.crdhook.orderselect.OrderSelectRequest;
-import org.hl7.davinci.r4.crdhook.CrdPrefetch;
 import org.hl7.davinci.r4.crdhook.DiscoveryExtension;
+import org.hl7.davinci.r4.crdhook.orderselect.OrderSelectRequest;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.slf4j.Logger;
@@ -43,6 +29,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import javax.validation.Valid;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 @Component
 public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -298,8 +298,6 @@ public abstract class CdsService<requestTypeT extends CdsRequest<?, ?>> {
       CoverageRequirementRuleResult lookupResult, CqlResultsForCard results) {
     List<Link> listOfLinks = new ArrayList<>();
     List<Pair<String, String>> linksToAdd = new ArrayList<>();
-    System.out.println(lookupResult.getCriteria().getPayor());
-    System.out.println(lookupResult.getCriteria().getPayorId());
     CoverageRequirements coverageRequirements = results.getCoverageRequirements();
     if (StringUtils.isNotEmpty(coverageRequirements.getQuestionnaireOrderUri())) {
       linksToAdd.add(Pair.of(coverageRequirements.getQuestionnaireOrderUri(), "Order Form"));

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/FhirBundleProcessor.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/FhirBundleProcessor.java
@@ -146,15 +146,17 @@ public class FhirBundleProcessor {
         
         String patientReference = deviceRequest.getSubject().getReference();
         List<Patient> referencedPrefetechedPatients = extractReferencedResources(patients, patientReference);
-            
         if (referencedPrefetechedPatients.size() < 1) {
-          logger.error("r4/FhirBundleProcessor::processDeviceRequests: ERROR - Device Request '"
+          logger.warn("r4/FhirBundleProcessor::processDeviceRequests: WARNING - Device Request '"
               + deviceRequest.getId() + "' does not contain a reference to any prefetched patients. Resource contains patient reference '"
               + patientReference + "' and prefetch contains patients " + patients.stream().map(patient -> patient.getId()).collect(Collectors.toSet()) + ".");
+          buildExecutionContexts(criteriaList, null, "device_request", deviceRequest);
+
+        } else {
+          Patient patientToUse = referencedPrefetechedPatients.get(0);
+          buildExecutionContexts(criteriaList, patientToUse, "device_request", deviceRequest);
         }
 
-        Patient patientToUse = referencedPrefetechedPatients.get(0);
-        buildExecutionContexts(criteriaList, patientToUse, "device_request", deviceRequest);
       }
     }
   }
@@ -174,15 +176,16 @@ public class FhirBundleProcessor {
         String patientReference = medicationRequest.getSubject().getReference();
 
         List<Patient> referencedPrefetechedPatients = extractReferencedResources(patients, patientReference);
+        List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(medicationRequest.getMedicationCodeableConcept(), medicationRequest.getInsurance(), payorList);
         if (referencedPrefetechedPatients.size() < 1) {
-          logger.error("r4/FhirBundleProcessor::processMedicationRequests: ERROR - Medication Request '"
+          logger.warn("r4/FhirBundleProcessor::processMedicationRequests: WARNING - Medication Request '"
               + medicationRequest.getId() + "' does not contain a reference to any prefetched patients. Resource contains patient reference '"
               + patientReference + "' and prefetch contains patients " + patients.stream().map(patient -> patient.getId()).collect(Collectors.toSet()) + ".");
+          buildExecutionContexts(criteriaList, null, "medication_request", medicationRequest);
+        } else {
+          Patient patientToUse = referencedPrefetechedPatients.get(0);
+          buildExecutionContexts(criteriaList, patientToUse, "medication_request", medicationRequest);
         }
-        
-        List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(medicationRequest.getMedicationCodeableConcept(), medicationRequest.getInsurance(), payorList);
-        Patient patientToUse = referencedPrefetechedPatients.get(0);
-        buildExecutionContexts(criteriaList, patientToUse, "medication_request", medicationRequest);
       }
     }
   }
@@ -204,15 +207,17 @@ public class FhirBundleProcessor {
       if (idInSelectionsList(medicationDispense.getId())) {
         String patientReference = medicationDispense.getSubject().getReference();
         List<Patient> referencedPrefetechedPatients = extractReferencedResources(patients, patientReference);
+        List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(medicationDispense.getMedicationCodeableConcept(), null, payorList);
         if (referencedPrefetechedPatients.size() < 1) {
-          logger.error("r4/FhirBundleProcessor::processMedicationDispenses: ERROR - Medication Dispense '"
+          logger.warn("r4/FhirBundleProcessor::processMedicationDispenses: WARNING - Medication Dispense '"
               + medicationDispense.getId() + "' does not contain a reference to any prefetched patients. Resource contains patient reference '"
               + patientReference + "' and prefetch contains patients " + patients.stream().map(patient -> patient.getId()).collect(Collectors.toSet()) + ".");
-          return;
+          buildExecutionContexts(criteriaList,null, "medication_dispense", medicationDispense);
+        } else {
+          Patient patientToUse = referencedPrefetechedPatients.get(0);
+          buildExecutionContexts(criteriaList,patientToUse, "medication_dispense", medicationDispense);
         }
-        List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(medicationDispense.getMedicationCodeableConcept(), null, payorList);
-        Patient patientToUse = referencedPrefetechedPatients.get(0);
-        buildExecutionContexts(criteriaList,patientToUse, "medication_dispense", medicationDispense);
+
       }
     }
   }
@@ -231,16 +236,18 @@ public class FhirBundleProcessor {
       if (idInSelectionsList(serviceRequest.getId())) {
         String patientReference = serviceRequest.getSubject().getReference();
         List<Patient> referencedPrefetechedPatients = extractReferencedResources(patients, patientReference);
+        List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(serviceRequest.getCode(), serviceRequest.getInsurance(), payorList);
         if (referencedPrefetechedPatients.size() < 1) {
-          logger.error("r4/FhirBundleProcessor::processServiceRequests: ERROR - Service Request '"
+          logger.warn("r4/FhirBundleProcessor::processServiceRequests: WARNING - Service Request '"
               + serviceRequest.getId() + "' does not contain a reference to any prefetched patients. Resource contains patient reference '"
               + patientReference + "' and prefetch contains patients " + patients.stream().map(patient -> patient.getId()).collect(Collectors.toSet()) + ".");
-
+          buildExecutionContexts(criteriaList, null, "service_request", serviceRequest);
+        } else {
+          Patient patientToUse = referencedPrefetechedPatients.iterator().next();
+          logger.info("r4/FhirBundleProcessor::processMedicationDispenses: Found Patient '" + patientToUse + "'.");
+          buildExecutionContexts(criteriaList, patientToUse, "service_request", serviceRequest);
         }
-        List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(serviceRequest.getCode(), serviceRequest.getInsurance(), payorList);
-        Patient patientToUse = referencedPrefetechedPatients.iterator().next();
-        logger.info("r4/FhirBundleProcessor::processMedicationDispenses: Found Patient '" + patientToUse + "'.");
-        buildExecutionContexts(criteriaList, patientToUse, "service_request", serviceRequest);
+
       }
     }
   }
@@ -268,21 +275,24 @@ public class FhirBundleProcessor {
           logger.info("r4/FhirBundleProcessor::processOrderSelectMedicationStatements: MedicationStatement found: " + medicationStatement.getId());
           String patientReference = medicationStatement.getSubject().getReference();
           List<Patient> referencedPrefetechedPatients = extractReferencedResources(medStatementPatients, patientReference);
+          List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(medicationRequest.getMedicationCodeableConcept(), medicationRequest.getInsurance(), payorList);
           if (referencedPrefetechedPatients.size() < 1) {
-            logger.error("r4/FhirBundleProcessor::processMedicationStatements: ERROR - Medication Statement '"
+            logger.warn("r4/FhirBundleProcessor::processMedicationStatements: WARNING - Medication Statement '"
                 + medicationStatement.getId() + "' does not contain a reference to any prefetched patients. Resource contains patient reference '"
                 + patientReference + "' and prefetch contains patients " + medStatementPatients.stream().map(patient -> patient.getId()).collect(Collectors.toSet()) + ".");
+            HashMap<String, Resource> cqlParams = new HashMap<>();
+            cqlParams.put("Patient", null);
+            cqlParams.put("medication_request", medicationRequest);
+            cqlParams.put("medication_statement", medicationStatement);
+            buildExecutionContexts(criteriaList, cqlParams);
+          } else {
+            Patient patientToUse = referencedPrefetechedPatients.get(0);
+            HashMap<String, Resource> cqlParams = new HashMap<>();
+            cqlParams.put("Patient", (Patient) patientToUse);
+            cqlParams.put("medication_request", medicationRequest);
+            cqlParams.put("medication_statement", medicationStatement);
+            buildExecutionContexts(criteriaList, cqlParams);
           }
-
-          List<CoverageRequirementRuleCriteria> criteriaList = createCriteriaList(medicationRequest.getMedicationCodeableConcept(), medicationRequest.getInsurance(), payorList);
-          Patient patientToUse = referencedPrefetechedPatients.get(0);
-
-          HashMap<String, Resource> cqlParams = new HashMap<>();
-          cqlParams.put("Patient", (Patient) patientToUse);
-          cqlParams.put("medication_request", medicationRequest);
-          cqlParams.put("medication_statement", medicationStatement);
-
-          buildExecutionContexts(criteriaList, cqlParams);
         }
       }
     }

--- a/server/src/main/java/org/hl7/davinci/endpoint/controllers/FhirController.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/controllers/FhirController.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 @RestController
 public class FhirController {
-  private static Logger logger = Logger.getLogger(Application.class.getName());
+  private static Logger logger = Logger.getLogger(FhirController.class.getName());
 
   @Autowired
   private FileStore fileStore;

--- a/server/src/main/java/org/hl7/davinci/endpoint/controllers/FhirController.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/controllers/FhirController.java
@@ -247,7 +247,6 @@ public class FhirController {
 
   private ResponseEntity<String> handleQuestionnaireOperation(HttpServletRequest request, HttpEntity<String> entity,
                                                               String fhirVersion, String questionnaireId) {
-    System.out.println(questionnaireId);
     fhirVersion = fhirVersion.toUpperCase();
     String baseUrl = Utils.getApplicationBaseUrl(request).toString() + "/";
 

--- a/server/src/main/java/org/hl7/davinci/endpoint/fhir/r4/QuestionnairePackageOperation.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/fhir/r4/QuestionnairePackageOperation.java
@@ -66,7 +66,6 @@ public class QuestionnairePackageOperation {
             //TODO: handle multiple FHIR Coverage Resources
             Coverage coverage = (Coverage) getResource(parameters, "coverage");
 
-            System.out.println(coverage);
             // list of all of the orders
             Bundle orders = getAllResources(parameters, "order");
             if (coverage == null || orders.isEmpty()) {
@@ -87,7 +86,6 @@ public class QuestionnairePackageOperation {
             fhirBundleProcessor.processServiceRequests(orders);
             fhirBundleProcessor.processMedicationDispenses(orders);
             List<String> topics = createTopicList(fhirBundleProcessor);
-            System.out.println(topics);
             for (String topic : topics) {
                 logger.info("--> process topic: " + topic);
                 if (questionnaireId == null) {

--- a/server/src/main/java/org/hl7/davinci/endpoint/fhir/r4/QuestionnairePackageOperation.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/fhir/r4/QuestionnairePackageOperation.java
@@ -66,9 +66,9 @@ public class QuestionnairePackageOperation {
             //TODO: handle multiple FHIR Coverage Resources
             Coverage coverage = (Coverage) getResource(parameters, "coverage");
 
+            System.out.println(coverage);
             // list of all of the orders
             Bundle orders = getAllResources(parameters, "order");
-
             if (coverage == null || orders.isEmpty()) {
                 logger.error("Failed to find order or coverage within parameters");
                 return null;
@@ -87,7 +87,7 @@ public class QuestionnairePackageOperation {
             fhirBundleProcessor.processServiceRequests(orders);
             fhirBundleProcessor.processMedicationDispenses(orders);
             List<String> topics = createTopicList(fhirBundleProcessor);
-
+            System.out.println(topics);
             for (String topic : topics) {
                 logger.info("--> process topic: " + topic);
 

--- a/server/src/main/java/org/hl7/davinci/endpoint/files/CommonFileStore.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/files/CommonFileStore.java
@@ -162,9 +162,9 @@ public abstract class CommonFileStore implements FileStore {
 
     List<FhirResource> fhirResourceList = fhirResources.findById(criteria);
     FileResource resource = readFhirResourceFromFiles(fhirResourceList, fhirVersion, baseUrl);
-    System.out.println("Resource Pulled: " + resource + "-" + resource.getFilename());
 
     if ((resource != null) && fhirVersion.equalsIgnoreCase("r4")) {
+      System.out.println("Resource Pulled: " + resource + "-" + resource.getFilename());
 
       // If this is a questionnaire, run it through the processor to modify it before
       // returning.


### PR DESCRIPTION
These changes are usable with DTR app context changes.  This doesn't really have much to do with relaunching other than modification of the Questionnaire operation to function properly when given an ID parameter.  

To test these changes, you can check the app context when loading DTR to find that it is conformant to the new IG standard, removing filepath and fhirpath and introducing coverage/response.  

Overall the major changes are:

- Modification of the smartLinkBuilder to produce the new appContext (CdsService)
- The introduction of an ID specific questionnaire-package endpoint to handle that case (FhirController) 
- Modification of the questionnaire-package operation to work with ID specific requests (QuestionnairePackageOperation)
