### PR TITLE
Query Batch Request Bug Fixes

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/CdsService.java
@@ -11,8 +11,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import javax.validation.Valid;
 
-import com.google.gson.Gson;
-
 import org.apache.commons.lang.StringUtils;
 import org.cdshooks.*;
 import org.hl7.davinci.FhirComponentsT;

--- a/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/FhirRequestProcessor.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/cdshooks/services/crd/r4/FhirRequestProcessor.java
@@ -192,6 +192,12 @@ public class FhirRequestProcessor {
   public static void addToCrdPrefetchRequest(CrdPrefetch crdResponse, ResourceType requestType,
       List<BundleEntryComponent> resourcesToAdd) {
     switch (requestType) {
+      case Coverage:
+        if (crdResponse.getCoverageBundle() == null) {
+          crdResponse.setCoverageBundle(new Bundle());
+        }
+        addNonDuplicateResourcesToBundle(crdResponse.getCoverageBundle(), resourcesToAdd);
+        break;
       case DeviceRequest:
         if (crdResponse.getDeviceRequestBundle() == null) {
           crdResponse.setDeviceRequestBundle(new Bundle());

--- a/server/src/main/java/org/hl7/davinci/endpoint/components/QueryBatchRequest.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/components/QueryBatchRequest.java
@@ -107,9 +107,6 @@ public class QueryBatchRequest {
     List<Coverage> coverages = FhirRequestProcessor.extractCoverageFromBundle(queryResponseBundle);
     List<Patient> patients = FhirRequestProcessor.extractPatientsFromBundle(queryResponseBundle);
     FhirRequestProcessor.addInsuranceAndSubject(initialRequestResource, patients, coverages);
-    BundleEntryComponent newEntry = new BundleEntryComponent();
-    newEntry.setResource(initialRequestResource);
-    queryResponseBundle.addEntry(newEntry);
 
     // Add the query batch response resources to the CRD Prefetch request.
     logger.info("Query Batch Response Entries: " + queryResponseBundle.getEntry());


### PR DESCRIPTION
This PR fixes two bugs with the Query Batch Request:

1. If there were any resources missing that should have been prefetched, the QBR would add a duplicate of the main request resources.
2. The QBR would only look at the first element of the draft orders, meaning that the QBR's requests would be flattened into the first prefetch bundle, rather than being inserted into the correct associated bundles.